### PR TITLE
chore: updating data definition for GradingJobOutput to include code …

### DIFF
--- a/docs/orca_data_definitions.md
+++ b/docs/orca_data_definitions.md
@@ -132,6 +132,7 @@ interface GradingJobOutput {
   shell_responses: [GradingScriptCommandResponse];
   errors?: [string];
   key: JSONString;
+  container_path: string;
 }
 
 interface GradingScriptCommandResponse {
@@ -143,6 +144,6 @@ interface GradingScriptCommandResponse {
 }
 ```
 
-The output includes the key given in the original job for use on the Bottlenose side. The `shell_responses` array contains a transcript of the output from each `GradingScriptCommand`.
+For use on the Bottlenose side, the output includes the key given in the original job, as well as the path code was stored in for formatting file paths in TAP. The `shell_responses` array contains a transcript of the output from each `GradingScriptCommand`.
 
 A successful `GradingJobOutput` will _always_ contain TAP output. An unsuccessful `GradingJobOutput` will still contain any responses of commands executed by the script; if the Orca VM harness fails (e.g., due to resource limits) the `errors` array will be non-empty.


### PR DESCRIPTION
## Feature/Problem Description
Bottlenose needs to be able to convert file paths from the Grading VM's container to upload paths on the server given TAP output.
This requires Orca to hand over the build directory where student code was stored during execution.

## Solution (Changes Made)
- Update the data definition for `GradingJobOutput` in the docs.
- Add the build path to the `GradingJobOutput` when TAP output exists.

