### PR TITLE
Worker handles SIGINT and SIGKILL.

### DIFF
--- a/grading-vm/.gitignore
+++ b/grading-vm/.gitignore
@@ -166,3 +166,7 @@ images/testing/simple-server/files/**/*
 !images/testing/simple-server/files/.gitkeep
 
 .vscode
+
+# Job Kill/Complete Signal Files
+.killjob
+.jobcompleted

--- a/grading-vm/orca_grader/__main__.py
+++ b/grading-vm/orca_grader/__main__.py
@@ -1,6 +1,8 @@
 import argparse
+import concurrent.futures
 import json
 import os
+import pathlib
 import subprocess
 import time
 import traceback
@@ -12,6 +14,7 @@ from orca_grader.common.services.push_results import push_results_to_bottlenose
 from orca_grader.common.types.grading_job_json_types import GradingJobJSON
 from orca_grader.config import APP_CONFIG
 from orca_grader.docker_utils.images.clean_up import clean_up_unused_images
+from orca_grader.exceptions import InvalidWorkerStateException
 from orca_grader.executor.builder.docker_grading_job_executor_builder import DockerGradingJobExecutorBuilder
 from orca_grader.executor.builder.grading_job_executor_builder import GradingJobExecutorBuilder
 from orca_grader.job_retrieval.local.local_grading_job_retriever import LocalGradingJobRetriever
@@ -20,6 +23,7 @@ from orca_grader.docker_utils.images.utils import does_image_exist
 from orca_grader.docker_utils.images.image_loading import retrieve_image_tgz_from_url, load_image_from_tgz
 from orca_grader.queue_diagnostics import log_diagnostics
 from orca_grader.queue_diagnostics import JobState
+from orca_grader.stop_worker import JOB_COMPLETED_FILE_NAME, KILL_JOB_FILE_NAME, GracefulKiller, JobKillObserver, reenqueue_job
 from orca_grader.validations.exceptions import InvalidGradingJobJSONException
 from orca_grader.validations.grading_job import is_valid_grading_job_json
 
@@ -32,6 +36,9 @@ def can_execute_job(job_json_string: str) -> bool:
     return False
 
 def run_grading_job(json_job_string: str, no_container: bool, container_command: Optional[List[str]]):
+  if not can_execute_job(json_job_string):
+    push_results_with_exception(json_job_string, InvalidGradingJobJSONException())
+    return
   if no_container:
     handle_grading_job(json_job_string)
     return
@@ -43,6 +50,7 @@ def run_grading_job(json_job_string: str, no_container: bool, container_command:
     handle_grading_job(json_job_string, container_sha, container_command)
   else:
     handle_grading_job(json_job_string, container_sha)
+  pathlib.Path(JOB_COMPLETED_FILE_NAME).touch()
 
 def handle_grading_job(grading_job_json_str: str, container_sha: str | None = None, 
     container_cmd: List[str] | None = None):
@@ -82,31 +90,46 @@ def push_results_with_exception(job_json_string: str, e: Exception):
 def run_local_job(job_path: str, no_container: bool, container_command: Optional[List[str]]):
   retriever = LocalGradingJobRetriever(job_path)
   job_string = retriever.retrieve_grading_job()
-  if not can_execute_job(job_string):
-    push_results_with_exception(job_string, InvalidGradingJobJSONException())
-  else:
-    run_grading_job(job_string, no_container, container_command)
+  run_grading_job(job_string, no_container, container_command)
   clean_up_unused_images()
 
 def process_redis_jobs(redis_url: str, no_container: bool, container_command: List[str] | None):
   retriever = RedisGradingJobRetriever(redis_url)
-  while True: 
+  killer = GracefulKiller()
+  while not killer.kill_now:
     job_string = retriever.retrieve_grading_job()
-    if not can_execute_job(job_string):
-      push_results_with_exception(job_string, InvalidGradingJobJSONException())
-      continue
-    run_grading_job(job_string, no_container, container_command)
-    if APP_CONFIG.enable_diagnostics:
-      log_diagnostics(get_redis_client(redis_url), 
-                      time.time_ns(), 
-                      json.loads(job_string)["key"],
-                      JobState.COMPLETED)
+    print(job_string[:10])
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as futures_executor:
+      job_kill_observer = JobKillObserver()
+      stop_future = futures_executor.submit(job_kill_observer.wait_for_jobkill_touch)
+      job_future = futures_executor.submit(run_grading_job, job_string, no_container, container_command)
+      done, not_done = concurrent.futures.wait([stop_future, job_future], return_when="FIRST_COMPLETED")
+      if stop_future in done and job_future in not_done:
+        reenqueue_job(json.loads(job_string), get_redis_client(redis_url))
+        return
+      if type(job_future.exception()) == InvalidWorkerStateException:
+        exit(1)
+      handle_completed_grading_job(job_string, redis_url)
+      clear_job_sig_files()
+
+def handle_completed_grading_job(job_string: str, redis_url: str):
+  if APP_CONFIG.enable_diagnostics:
+    log_diagnostics(get_redis_client(redis_url), 
+                    time.time_ns(), 
+                    json.loads(job_string)["key"],
+                    JobState.COMPLETED)
     clean_up_unused_images()
 
 def get_container_sha(json_job_string: str) -> str:
   return json.loads(json_job_string)["grader_image_sha"]
 
+def clear_job_sig_files():
+  for name in (KILL_JOB_FILE_NAME, JOB_COMPLETED_FILE_NAME):
+    if os.path.exists(name):
+      os.remove(name)
+
 if __name__ == "__main__":
+  clear_job_sig_files()
   arg_parser = argparse.ArgumentParser(
       prog="Orca Grader",
       description="Pulls a job from a Redis queue and executes a script to autograde." 

--- a/grading-vm/orca_grader/exceptions.py
+++ b/grading-vm/orca_grader/exceptions.py
@@ -1,0 +1,8 @@
+class InvalidWorkerStateException(Exception):
+  """
+  Exception used to signal the the worker should be shut down altogether.
+  """
+  
+  def __init__(self, msg: str = "The worker has reached an unclean state; this is most likely caused " \
+               "by failure to shutdown a running job container.") -> None:
+    self.msg = msg

--- a/grading-vm/orca_grader/executor/docker_grading_job_executor.py
+++ b/grading-vm/orca_grader/executor/docker_grading_job_executor.py
@@ -1,4 +1,5 @@
 import subprocess
+from orca_grader.exceptions import InvalidWorkerStateException
 from orca_grader.executor.grading_job_executor import GradingJobExecutor
 from typing import List, Callable
 from subprocess import CompletedProcess, TimeoutExpired
@@ -17,5 +18,4 @@ class DockerGradingJobExecutor(GradingJobExecutor):
       subprocess.run(["docker", "stop", "-t", f"{self.__DOCKER_CONTAINER_STOPPAGE_TIMEOUT}", self.__container_name],
         stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT, timeout=self.__DOCKER_CONTAINER_STOPPAGE_TIMEOUT+self.__STOP_BUFFER)
     except TimeoutExpired:
-      print("Failed to stop container.")
-      pass
+      raise InvalidWorkerStateException()

--- a/grading-vm/orca_grader/stop_worker.py
+++ b/grading-vm/orca_grader/stop_worker.py
@@ -1,0 +1,51 @@
+import json
+import signal
+import pathlib
+import os
+import time
+import redis
+
+from orca_grader.common.types.grading_job_json_types import GradingJobJSON
+
+KILL_JOB_FILE_NAME = '.killjob'
+JOB_COMPLETED_FILE_NAME = '.jobcompleted'
+
+class GracefulKiller:
+  """
+  Idea pulled from https://stackoverflow.com/questions/18499497/how-to-process-sigterm-signal-gracefully.
+  """
+  
+  def __init__(self) -> None:
+    self.kill_now = False
+    signal.signal(signal.SIGINT, self.exit_gracefully)
+    signal.signal(signal.SIGTERM, self.exit_gracefully)
+
+  def exit_gracefully(self, *args):
+    pathlib.Path(KILL_JOB_FILE_NAME).touch()
+    self.kill_now = True
+
+class JobKillObserver:
+
+  def __init__(self) -> None:
+    self.__job_completed = False
+    self.__kill_job = False
+
+  def wait_for_jobkill_touch(self):
+    while not self.__kill_job_sig_received() and not self.__job_completed_sig_received():
+      continue
+
+  def __kill_job_sig_received(self):
+    self.__kill_job = os.path.exists(KILL_JOB_FILE_NAME)
+    return self.__kill_job
+
+  def __job_completed_sig_received(self):
+    self.__job_completed = os.path.exists(JOB_COMPLETED_FILE_NAME)
+    return self.__job_completed
+
+def reenqueue_job(grading_job_json: GradingJobJSON, client: redis.Redis) -> None:
+  if not client.exists(grading_job_json['key']):
+    client.set(grading_job_json['key'], json.dumps(grading_job_json))
+  arrival_time = time.time_ns()
+  client.zadd('Reservations',
+              {f'immediate.{grading_job_json["key"]}': 
+               arrival_time + grading_job_json['priority']})


### PR DESCRIPTION
## Feature/Problem Description
Workers populated by a larger Kubernetes system should be able to handle being shut down (e.g., in a scale down scenario). This means ensuring that a job that has not been completed is able to be regraded and picked up again ASAP.

## Solution (Changes Made)
* `GracefulKiller` class to manage signal handling.
* Observer to look for a `.jobcompleted` or `.killjob` file to signify the termination of a job.
** The former case is needed to ensure the thread (wrapped by a `Future`) does not run forever.
* Re-enqueue function for when a job is killed prematurely.
