### PR TITLE
Proof of Concept for Removing Nonces from Queue Operations

### DIFF
--- a/web-server/src/grading-queue/service/index.ts
+++ b/web-server/src/grading-queue/service/index.ts
@@ -83,13 +83,8 @@ export class GradingQueueService {
               `Could not find job with key ${orcaKey}`,
             );
           }
-          const {
-            created_at,
-            release_at,
-            orca_key,
-            arrivalTime,
-            ...baseGradingJob
-          } = JSON.parse(currentJob) as GradingJob;
+          const { created_at, release_at, orca_key, ...baseGradingJob } =
+            JSON.parse(currentJob) as GradingJob;
           await this.createOrUpdateJob(
             baseGradingJob,
             created_at,

--- a/web-server/src/grading-queue/types.ts
+++ b/web-server/src/grading-queue/types.ts
@@ -54,7 +54,6 @@ interface AdditionalJobData {
   release_at: number;
   created_at: number;
   orca_key: string;
-  arrivalTime?: number;
 }
 
 export type GradingJob = GradingJobConfig & AdditionalJobData;

--- a/web-server/src/grading-queue/types.ts
+++ b/web-server/src/grading-queue/types.ts
@@ -54,7 +54,7 @@ interface AdditionalJobData {
   release_at: number;
   created_at: number;
   orca_key: string;
-  nonce?: number;
+  arrivalTime?: number;
 }
 
 export type GradingJob = GradingJobConfig & AdditionalJobData;
@@ -87,7 +87,7 @@ export interface GradingQueueStats {
 export type MoveJobAction = "release" | "delay";
 
 export interface MoveJobRequest {
-  nonce: number;
+  arrivalTime: number;
   orcaKey: string;
   moveAction: MoveJobAction;
   collation: Collation;
@@ -95,7 +95,7 @@ export interface MoveJobRequest {
 
 export interface DeleteJobRequest {
   orcaKey: string;
-  nonce?: number;
+  arrivalTime?: number;
   collation?: Collation;
 }
 

--- a/web-server/src/validations/__mocks__/delete-request.mock.ts
+++ b/web-server/src/validations/__mocks__/delete-request.mock.ts
@@ -6,7 +6,7 @@ export const validImmediateDeleteRequest: DeleteJobRequest = {
 
 export const validDeleteRequest: DeleteJobRequest = {
   ...validImmediateDeleteRequest,
-  nonce: 12345,
+  arrivalTime: 12345,
   collation: {
     type: "user",
     id: "12345",

--- a/web-server/src/validations/__tests__/index.test.ts
+++ b/web-server/src/validations/__tests__/index.test.ts
@@ -25,11 +25,11 @@ describe("JSONSchema validations", () => {
   });
 
   describe("DeleteJobRequest schema validation", () => {
-    it("validates a request with a key, nonce, and user collation", () => {
+    it("validates a request with a key, arrivalTime, and user collation", () => {
       expect(validations.deleteJobRequest(validDeleteRequest)).toBe(true);
     });
 
-    it("validates a request with a key, nonce, and team collation", () => {
+    it("validates a request with a key, arrivalTime, and team collation", () => {
       expect(
         validations.deleteJobRequest({
           ...validDeleteRequest,

--- a/web-server/src/validations/schemas/delete-job-request.ts
+++ b/web-server/src/validations/schemas/delete-job-request.ts
@@ -4,7 +4,7 @@ export const deleteJobRequestSchema = {
   properties: {
     orcaKey: { type: "string" },
     collation: { $ref: "https://orca-schemas.com/shared/collation" },
-    nonce: { type: "number" },
+    arrivalTime: { type: "number" },
   },
   required: ["orcaKey"],
 } as const;

--- a/web-server/src/validations/schemas/move-job-request.ts
+++ b/web-server/src/validations/schemas/move-job-request.ts
@@ -2,7 +2,7 @@ export const moveJobRequestSchema = {
   $id: "https://orca-schemas.com/move-job-request",
   type: "object",
   properties: {
-    nonce: { type: "number" },
+    arrivalTime: { type: "number" },
     orcaKey: { type: "string" },
     moveAction: { enum: ["delay", "release"] },
     collation: { $ref: "https://orca-schemas.com/shared/collation" },


### PR DESCRIPTION
## Feature/Problem Description

Nonces prove to be somewhat unuseful, as we can simply utilize the arrival times of jobs as a mode of uniqueness.

Further, they become create state issues if they need to be regenerated on the worker side when reeqneueing a job after enterring a forced shutdown state.

## Solution (Changes Made)
* Replace uses of nonces in queue operations with arrival timestamp.
* Change delete and move request schemas to utilize arrival time instead of nonce.

