### PR TITLE
Feature: Jobs can specify optional container-specific response url

### DIFF
--- a/docs/orca_data_definitions.md
+++ b/docs/orca_data_definitions.md
@@ -17,11 +17,12 @@ A `GradingJob` contains details about how to grade a submission.
 interface GradingJob {
   key: JSONString;
   collation: Collation;
-  metadata_table: Map<string, string>;
-  files: Map<string, CodeFileInfo>;
+  metadata_table: Record<string, string>;
+  files: Record<string, CodeFileInfo>;
   priority: integer;
   script: GradingScriptCommand[];
   response_url: string;
+  container_response_url?: string;
   grader_image_sha: string;
 }
 ```
@@ -87,7 +88,7 @@ Grading jobs have a numeric priority determined by Bottlenose, which is interpre
 
 Jobs are run inside Docker containers to provide a level of isolation from the local machine. When an assignment is generated, professors will provide a Dockerfile to build their grader image. Orca's web server will build this image and save it to a .tgz file with the name `<SHA>.tgz`, where `<SHA>` is the SHA sum generated from the image's Dockerfile.
 
-The grading VM will use the `container_sha`'s value to determine if the image already exists on its local machine or if it should be downloaded from the URL `https://<orca-server-hostname>/images/<SHA>.tgz`.
+The grading VM will use the `grader_image_sha`'s value to determine if the image already exists on its local machine or if it should be downloaded from the URL `https://<orca-server-hostname>/images/<SHA>.tgz`.
 
 The script defines the actual grading process, as a state machine specified below.
 
@@ -137,7 +138,7 @@ Simlar to the `BashGradingScriptCommand`, the optional `on_true` and `on_false` 
 
 ## `GradingJobResult`
 
-Execution of a grading job will result in a `GradingJobResult` object to send back data to a given job's `response_url`.
+Execution of a grading job will result in a `GradingJobResult` object to send back data to a given job's `response_url`. _Optionally_, a `container_response_url` may be included for local development as if the grading container needs to contact an test echo server also running in a container, then there will be a need for separate `http://localhost` and `http://<container_name>` URLs.
 
 ```typescript
 interface GradingJobResult {

--- a/grading-vm/orca_grader/container/do_grading.py
+++ b/grading-vm/orca_grader/container/do_grading.py
@@ -1,7 +1,6 @@
 import json
 import os
 import shutil
-import sys
 import traceback
 from typing import Dict, List, TextIO
 from orca_grader.common.services.push_results import push_results_to_response_url
@@ -52,7 +51,10 @@ def do_grading(secret: str, grading_job_json: GradingJobJSON) -> GradingJobResul
     output = GradingJobResult(command_responses, [preprocess_e])
   except Exception as e:
     output = GradingJobResult(command_responses, [e])
-  push_results_to_response_url(output, grading_job_json["key"], grading_job_json["response_url"])
+  push_results_to_response_url(output, grading_job_json["key"],
+                               grading_job_json["container_response_url"] if \
+                                "container_response_url" in grading_job_json else \
+                                  grading_job_json["response_url"])
   return output
 
 if __name__ == "__main__":

--- a/grading-vm/orca_grader/container/do_grading.py
+++ b/grading-vm/orca_grader/container/do_grading.py
@@ -51,7 +51,8 @@ def do_grading(secret: str, grading_job_json: GradingJobJSON) -> GradingJobResul
     output = GradingJobResult(command_responses, [preprocess_e])
   except Exception as e:
     output = GradingJobResult(command_responses, [e])
-  push_results_to_response_url(output, grading_job_json["key"],
+  push_results_to_response_url(output,
+                               grading_job_json["key"],
                                grading_job_json["container_response_url"] if \
                                 "container_response_url" in grading_job_json else \
                                   grading_job_json["response_url"])
@@ -67,6 +68,10 @@ if __name__ == "__main__":
   except Exception as e:
     traceback.print_tb(e.__traceback__)
     output = GradingJobResult([], [e.with_traceback(None)])
-    push_results_to_response_url(output, grading_job["key"], grading_job["response_url"])
+    push_results_to_response_url(output,
+                                 grading_job["key"],
+                                 grading_job["container_response_url"] if \
+                                  "container_response_url" in grading_job else \
+                                    grading_job["response_url"])
   # cleanup(secret) # useful for execution with no container, but generally optional
 

--- a/grading-vm/orca_grader/tests/scripts/seed_test_db.py
+++ b/grading-vm/orca_grader/tests/scripts/seed_test_db.py
@@ -25,7 +25,8 @@ __BASIC_GRADING_JOB_SCAFFOLDING = {
   'collation': {
     'type': 'user'
   },
-  'response_url': 'http://echo-server:9001/job-output',
+  'response_url': 'http://localhost:9001/job-output',
+  'container_response_url': 'http://echo-server:9001/job-output',
   'files': {},
   'metadata_table': {}
 }

--- a/grading-vm/orca_grader/validations/schemas/grading_job_schema.json
+++ b/grading-vm/orca_grader/validations/schemas/grading_job_schema.json
@@ -30,8 +30,21 @@
     "response_url": {
       "type": "string"
     },
+    "container_response_url": {
+      "type": "string"
+    },
     "grader_image_sha": {
       "type": "string"
     }
-  }
+  },
+  "required": [
+    "key",
+    "collation",
+    "metadata_table",
+    "files",
+    "priority",
+    "script",
+    "response_url",
+    "grader_image_sha"
+  ]
 }


### PR DESCRIPTION
## Feature/Problem Description
For a given grading job, when the worker runs it in the container and needs to push the results to a URL for a server that is _also running in a container_, then due to the nature of Docker container networking, the response cannot be sent to a `localhost` URL, but instead a URL of host `<container_name>`. This mainly applies for local development when sending job results to the echo server provided in `grading-vm/`.

## Solution (Changes Made)
* Update data definition in documentation.
* Update `do_grading` to reflect use of secondary URL.
* Update JSONSchema to reflect new optional field when running validations. 

