### PR TITLE
Feat/job cancellation orchestrator

### DIFF
--- a/orchestrator/init_dev.sh
+++ b/orchestrator/init_dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 prisma_migration () {
   docker pull postgres:10
-  docker run -p 5432:5432 -v db-data:/var/lib/postgresql/data -e POSTGRES_PASSWORD=password \
+  docker run -p 5434:5432 -v db-data:/var/lib/postgresql/data -e POSTGRES_PASSWORD=password \
     -d --name postgres postgres:10
   npx prisma migrate dev --name init
 }

--- a/orchestrator/packages/api/src/__mocks__/grader-image-build-request.ts
+++ b/orchestrator/packages/api/src/__mocks__/grader-image-build-request.ts
@@ -1,7 +1,8 @@
 import { GraderImageBuildRequest } from "@codegrade-orca/common";
 
 export const defaultGraderImageBuildRequest: GraderImageBuildRequest = {
-  dockerfileContents: `FROM hello-world:latest`,
-  dockerfileSHASum: "generated-sha-sum",
-  responseURL: "http://example.com/response"
+  dockerfile_contents: `FROM hello-world:latest`,
+  dockerfile_sha_sum: "generated-sha-sum",
+  response_url: "http://example.com/response",
+  build_key: "{\"grader_id\": 1}"
 };

--- a/orchestrator/packages/api/src/__mocks__/grader-image-build-request.ts
+++ b/orchestrator/packages/api/src/__mocks__/grader-image-build-request.ts
@@ -3,4 +3,5 @@ import { GraderImageBuildRequest } from "@codegrade-orca/common";
 export const defaultGraderImageBuildRequest: GraderImageBuildRequest = {
   dockerfileContents: `FROM hello-world:latest`,
   dockerfileSHASum: "generated-sha-sum",
+  responseURL: "http://example.com/response"
 };

--- a/orchestrator/packages/api/src/controllers/grading-queue-controller.ts
+++ b/orchestrator/packages/api/src/controllers/grading-queue-controller.ts
@@ -5,9 +5,10 @@ import {
   getPageFromGradingQueue as getPageFromGradingJobs,
 } from "../utils/pagination";
 import { validateFilterRequest } from "../utils/validate";
-import { errorResponse } from "./utils";
+import { errorResponse, notifyClientOfCancelledJob } from "./utils";
 import {
   GradingJob,
+  GradingJobConfig,
   filterGradingJobs,
   getFilterInfo,
   getGradingQueueStats,
@@ -163,7 +164,9 @@ export const deleteJob = async (req: Request, res: Response) => {
     if (isNaN(jobID)) {
       return errorResponse(res, 400, ["Given job ID is not a number."]);
     }
-    await deleteJobInQueue(jobID);
+    const deletedJob = await deleteJobInQueue(jobID);
+    const deletedJobConfig = deletedJob.config as object as GradingJobConfig;
+    await notifyClientOfCancelledJob(deletedJobConfig)
     return res.status(200).json({ message: "OK" });
   } catch (err) {
     if (err instanceof GradingQueueOperationException) {

--- a/orchestrator/packages/api/src/controllers/utils.ts
+++ b/orchestrator/packages/api/src/controllers/utils.ts
@@ -11,7 +11,6 @@ export const errorResponse = (
 
 export const notifyClientOfCancelledJob = async (jobConfig: GradingJobConfig) => {
   const result: GradingJobResult = {
-    type: "GradingJobResult",
     shell_responses: [],
     errors: ["Job cancelled by a course professor or Orca admin."]
   };

--- a/orchestrator/packages/api/src/controllers/utils.ts
+++ b/orchestrator/packages/api/src/controllers/utils.ts
@@ -1,3 +1,4 @@
+import { GradingJobConfig, GradingJobResult } from "@codegrade-orca/common";
 import { Response } from "express";
 
 export const errorResponse = (
@@ -7,3 +8,21 @@ export const errorResponse = (
 ) => {
   return res.status(status).json({ errors: errors });
 };
+
+export const notifyClientOfCancelledJob = async (jobConfig: GradingJobConfig) => {
+  const result: GradingJobResult = {
+    shell_responses: [],
+    errors: ["Job cancelled by a course professor or Orca admin."]
+  };
+  await fetch(jobConfig.response_url, {
+    method: "POST",
+    headers: {
+      "Accept": "application/json",
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ result, key: jobConfig.key })
+  }).catch((err) =>
+    console.error(
+      `Encountered the following error while attempting to notify client of Job cancellation: ${err}`
+    ));
+}

--- a/orchestrator/packages/api/src/controllers/utils.ts
+++ b/orchestrator/packages/api/src/controllers/utils.ts
@@ -11,6 +11,7 @@ export const errorResponse = (
 
 export const notifyClientOfCancelledJob = async (jobConfig: GradingJobConfig) => {
   const result: GradingJobResult = {
+    type: "GradingJobResult",
     shell_responses: [],
     errors: ["Job cancelled by a course professor or Orca admin."]
   };

--- a/orchestrator/packages/common/src/types/image-build-service.ts
+++ b/orchestrator/packages/common/src/types/image-build-service.ts
@@ -1,32 +1,27 @@
 export interface GraderImageBuildResult {
-  build_logs: Array<ImageBuildLog>,
-  was_successful: boolean
-  server_exception?: string,
-  dockerfile_sha_sum: string
+  was_successful: boolean,
+  logs: Array<ImageBuildLog>
 }
-
-export interface ImageBuildFailure {
-  error: Error,
-  logs: Array<ImageBuildLog>,
-};
 
 export type ImageBuildStep = "Write request contents to Dockerfile." |
   "Run docker build on Dockerfile." |
   "Save image to .tgz file." |
-  "Remove residual Dockerfile.";
+  "Remove Dockerfile.";
 
 export interface ImageBuildLog {
   step: ImageBuildStep,
-  cmd?: string | Array<string>,
-  stderr: string
+  output?: string,
+  error?: string
 }
 
-export const isImageBuildFailure = (object: unknown): object is ImageBuildFailure => {
-  return !!object && typeof object === "object" && "error" in object && "logs" in object;
+export const isImageBuildResult = (o: unknown): o is GraderImageBuildResult => {
+  if (typeof o !== "object" || o === null) return false;
+  return Object.keys(o).length == 2 && ["was_successful", "logs"].every((k) => k in o);
 }
 
 export interface GraderImageBuildRequest {
-  dockerfileContents: string;
-  dockerfileSHASum: string;
-  responseURL: string;
+  dockerfile_contents: string,
+  dockerfile_sha_sum: string,
+  response_url: string,
+  build_key: string,
 }

--- a/orchestrator/packages/common/src/types/image-build-service.ts
+++ b/orchestrator/packages/common/src/types/image-build-service.ts
@@ -1,4 +1,32 @@
+export interface GraderImageBuildResult {
+  build_logs: Array<ImageBuildLog>,
+  was_successful: boolean
+  server_exception?: string,
+  dockerfile_sha_sum: string
+}
+
+export interface ImageBuildFailure {
+  error: Error,
+  logs: Array<ImageBuildLog>,
+};
+
+export type ImageBuildStep = "Write request contents to Dockerfile." |
+  "Run docker build on Dockerfile." |
+  "Save image to .tgz file." |
+  "Remove residual Dockerfile.";
+
+export interface ImageBuildLog {
+  step: ImageBuildStep,
+  cmd?: string | Array<string>,
+  stderr: string
+}
+
+export const isImageBuildFailure = (object: unknown): object is ImageBuildFailure => {
+  return !!object && typeof object === "object" && "error" in object && "logs" in object;
+}
+
 export interface GraderImageBuildRequest {
   dockerfileContents: string;
   dockerfileSHASum: string;
+  responseURL: string;
 }

--- a/orchestrator/packages/common/src/types/index.ts
+++ b/orchestrator/packages/common/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./grading-queue";
 export * from "./image-build-service";
+export * from "./job-result";

--- a/orchestrator/packages/common/src/types/job-result.ts
+++ b/orchestrator/packages/common/src/types/job-result.ts
@@ -1,4 +1,33 @@
+export interface GraderImageBuildResult {
+  type: "GraderImageBuildResult",
+  build_logs: Array<ImageBuildLog>,
+  was_successful: boolean
+  server_exception?: string,
+  dockerfile_sha_sum: string
+}
+
+export interface ImageBuildFailure {
+  error: Error,
+  logs: Array<ImageBuildLog>,
+};
+
+export type ImageBuildStep = "Write request contents to Dockerfile." |
+  "Run docker build on Dockerfile." |
+  "Save image to .tgz file." |
+  "Remove residual Dockerfile.";
+
+export interface ImageBuildLog {
+  step: ImageBuildStep,
+  cmd?: string | Array<string>,
+  stderr: string
+}
+
+export const isImageBuildFailure = (object: unknown): object is ImageBuildFailure => {
+  return !!object && typeof object === "object" && "error" in object && "logs" in object;
+}
+
 export interface GradingJobResult {
+  type: "GradingJobResult",
   shell_responses: Array<GradingScriptCommandResponse>,
   errors: Array<string>,
   output?: string

--- a/orchestrator/packages/common/src/types/job-result.ts
+++ b/orchestrator/packages/common/src/types/job-result.ts
@@ -1,33 +1,4 @@
-export interface GraderImageBuildResult {
-  type: "GraderImageBuildResult",
-  build_logs: Array<ImageBuildLog>,
-  was_successful: boolean
-  server_exception?: string,
-  dockerfile_sha_sum: string
-}
-
-export interface ImageBuildFailure {
-  error: Error,
-  logs: Array<ImageBuildLog>,
-};
-
-export type ImageBuildStep = "Write request contents to Dockerfile." |
-  "Run docker build on Dockerfile." |
-  "Save image to .tgz file." |
-  "Remove residual Dockerfile.";
-
-export interface ImageBuildLog {
-  step: ImageBuildStep,
-  cmd?: string | Array<string>,
-  stderr: string
-}
-
-export const isImageBuildFailure = (object: unknown): object is ImageBuildFailure => {
-  return !!object && typeof object === "object" && "error" in object && "logs" in object;
-}
-
 export interface GradingJobResult {
-  type: "GradingJobResult",
   shell_responses: Array<GradingScriptCommandResponse>,
   errors: Array<string>,
   output?: string

--- a/orchestrator/packages/common/src/types/job-result.ts
+++ b/orchestrator/packages/common/src/types/job-result.ts
@@ -1,0 +1,14 @@
+export interface GradingJobResult {
+  shell_responses: Array<GradingScriptCommandResponse>,
+  errors: Array<string>,
+  output?: string
+}
+
+interface GradingScriptCommandResponse {
+  cmd: string | Array<string>,
+  stdout: string,
+  stderr: string,
+  did_timeout: boolean,
+  is_error: boolean,
+  status_code: number
+}

--- a/orchestrator/packages/common/src/validations/__mocks__/grader-image-build-request.ts
+++ b/orchestrator/packages/common/src/validations/__mocks__/grader-image-build-request.ts
@@ -1,7 +1,8 @@
 import { GraderImageBuildRequest } from "../../types/image-build-service";
 
 export const defaultGraderImageBuildRequest: GraderImageBuildRequest = {
-  dockerfileContents: `FROM hello-world:latest`,
-  dockerfileSHASum: "generated-sha-sum",
-  responseURL: "http://example.com/response"
+  dockerfile_contents: `FROM hello-world:latest`,
+  dockerfile_sha_sum: "generated-sha-sum",
+  response_url: "http://example.com/response",
+  build_key: "{\"grader_id\": 1}"
 };

--- a/orchestrator/packages/common/src/validations/__mocks__/grader-image-build-request.ts
+++ b/orchestrator/packages/common/src/validations/__mocks__/grader-image-build-request.ts
@@ -3,4 +3,5 @@ import { GraderImageBuildRequest } from "../../types/image-build-service";
 export const defaultGraderImageBuildRequest: GraderImageBuildRequest = {
   dockerfileContents: `FROM hello-world:latest`,
   dockerfileSHASum: "generated-sha-sum",
+  responseURL: "http://example.com/response"
 };

--- a/orchestrator/packages/common/src/validations/schemas/grader-image-build-request.ts
+++ b/orchestrator/packages/common/src/validations/schemas/grader-image-build-request.ts
@@ -2,8 +2,9 @@ export const graderImageBuildRequestSchema = {
   $id: "https://orca-schemas.com/grader-image-build-request",
   type: "object",
   properties: {
-    dockerfileContents: { type: "string" },
-    dockerfileSHASum: { type: "string" },
-    responseURL: { type: "string" }
+    dockerfile_contents: { type: "string" },
+    dockerfile_sha_sum: { type: "string" },
+    response_url: { type: "string" },
+    build_key: { type: "string" },
   },
 } as const;

--- a/orchestrator/packages/common/src/validations/schemas/grader-image-build-request.ts
+++ b/orchestrator/packages/common/src/validations/schemas/grader-image-build-request.ts
@@ -4,5 +4,6 @@ export const graderImageBuildRequestSchema = {
   properties: {
     dockerfileContents: { type: "string" },
     dockerfileSHASum: { type: "string" },
+    responseURL: { type: "string" }
   },
 } as const;

--- a/orchestrator/packages/db/prisma/migrations/20240714175155_init/migration.sql
+++ b/orchestrator/packages/db/prisma/migrations/20240714175155_init/migration.sql
@@ -38,6 +38,7 @@ CREATE TABLE "Job" (
 CREATE TABLE "ImageBuildInfo" (
     "dockerfileSHA" TEXT NOT NULL,
     "dockerfileContent" TEXT NOT NULL,
+    "responseURL" TEXT NOT NULL,
     "inProgress" BOOLEAN NOT NULL DEFAULT false,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 

--- a/orchestrator/packages/db/prisma/migrations/20240720201049_init/migration.sql
+++ b/orchestrator/packages/db/prisma/migrations/20240720201049_init/migration.sql
@@ -38,6 +38,7 @@ CREATE TABLE "Job" (
 CREATE TABLE "ImageBuildInfo" (
     "dockerfileSHA" TEXT NOT NULL,
     "dockerfileContent" TEXT NOT NULL,
+    "buildKey" TEXT NOT NULL,
     "responseURL" TEXT NOT NULL,
     "inProgress" BOOLEAN NOT NULL DEFAULT false,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -65,6 +66,9 @@ CREATE UNIQUE INDEX "Submitter_clientURL_collationType_collationID_key" ON "Subm
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Job_clientURL_clientKey_key" ON "Job"("clientURL", "clientKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ImageBuildInfo_buildKey_responseURL_key" ON "ImageBuildInfo"("buildKey", "responseURL");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "JobConfigAwaitingImage_clientKey_clientURL_key" ON "JobConfigAwaitingImage"("clientKey", "clientURL");

--- a/orchestrator/packages/db/prisma/schema.prisma
+++ b/orchestrator/packages/db/prisma/schema.prisma
@@ -60,11 +60,14 @@ model Job {
 model ImageBuildInfo {
   dockerfileSHA String @id
   dockerfileContent String
+  buildKey String
   responseURL String
   inProgress Boolean @default(false)
   createdAt DateTime @default(now())
 
   jobConfigs JobConfigAwaitingImage[]
+
+  @@unique([buildKey, responseURL])
 }
 
 model JobConfigAwaitingImage {

--- a/orchestrator/packages/db/prisma/schema.prisma
+++ b/orchestrator/packages/db/prisma/schema.prisma
@@ -60,6 +60,7 @@ model Job {
 model ImageBuildInfo {
   dockerfileSHA String @id
   dockerfileContent String
+  responseURL String
   inProgress Boolean @default(false)
   createdAt DateTime @default(now())
 

--- a/orchestrator/packages/db/run-migration
+++ b/orchestrator/packages/db/run-migration
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [[ "$#" -ne 1 ]]; then
   echo "Please pass a *single* argument for migration name."
   exit 1
@@ -8,7 +10,7 @@ fi
 migration_name="$1"
 container_name='postgres-migration'
 
-docker run --rm -p 5432:5432 -v db-data:/var/lib/postgresql/data \
+docker run --rm -p 5434:5432 -v db-data:/var/lib/postgresql/data \
   -e POSTGRES_PASSWORD=password --name "$container_name" -d postgres:10 > /dev/null
 
 if [[ $? -ne 0  ]]; then

--- a/orchestrator/packages/db/src/image-builder-operations/index.ts
+++ b/orchestrator/packages/db/src/image-builder-operations/index.ts
@@ -2,4 +2,4 @@ import getNextImageBuild from "./get-next-image-build";
 import handleCompletedImageBuild from "./handle-completed-image-build";
 
 export { getNextImageBuild };
-export { handleCompletedImageBuild  };
+export { handleCompletedImageBuild };

--- a/orchestrator/packages/db/src/server-operations/delete-job.ts
+++ b/orchestrator/packages/db/src/server-operations/delete-job.ts
@@ -2,7 +2,7 @@ import { getAssociatedReservation, retireReservationAndJob } from "../utils";
 import prismaInstance from "../prisma-instance";
 import { Job } from "@prisma/client";
 
-const deleteJob = (jobID: number) =>
+const deleteJob = (jobID: number): Promise<Job> =>
   prismaInstance.$transaction(async (tx) => {
     const job = await tx.job.findUnique({
       where: {
@@ -11,6 +11,7 @@ const deleteJob = (jobID: number) =>
     }) as Job;
     const reservation = await getAssociatedReservation(job, tx);
     await retireReservationAndJob(job, reservation, tx);
+    return job;
   });
 
 export default deleteJob;

--- a/orchestrator/packages/db/src/server-operations/enqueue-image-build.ts
+++ b/orchestrator/packages/db/src/server-operations/enqueue-image-build.ts
@@ -1,12 +1,13 @@
 import { GraderImageBuildRequest } from '@codegrade-orca/common';
 import prismaInstance from '../prisma-instance';
 
-const enqueueImageBuild = ({ dockerfileSHASum, dockerfileContents }: GraderImageBuildRequest): Promise<boolean> => {
+const enqueueImageBuild = ({ dockerfileSHASum, dockerfileContents, responseURL }: GraderImageBuildRequest): Promise<boolean> => {
   return prismaInstance.$transaction(async (tx) => {
     const buildInfoAlreadyExists = (await tx.imageBuildInfo.count({
       where: {
         dockerfileSHA: dockerfileSHASum,
-        dockerfileContent: dockerfileContents
+        dockerfileContent: dockerfileContents,
+        responseURL
       }
     })) > 0;
     if (buildInfoAlreadyExists) {
@@ -15,7 +16,8 @@ const enqueueImageBuild = ({ dockerfileSHASum, dockerfileContents }: GraderImage
       await tx.imageBuildInfo.create({
         data: {
           dockerfileSHA: dockerfileSHASum,
-          dockerfileContent: dockerfileContents
+          dockerfileContent: dockerfileContents,
+          responseURL
         }
       });
       return true;

--- a/orchestrator/packages/db/src/server-operations/enqueue-image-build.ts
+++ b/orchestrator/packages/db/src/server-operations/enqueue-image-build.ts
@@ -1,13 +1,11 @@
 import { GraderImageBuildRequest } from '@codegrade-orca/common';
 import prismaInstance from '../prisma-instance';
 
-const enqueueImageBuild = ({ dockerfileSHASum, dockerfileContents, responseURL }: GraderImageBuildRequest): Promise<boolean> => {
+const enqueueImageBuild = ({ dockerfile_sha_sum, dockerfile_contents, response_url, build_key }: GraderImageBuildRequest): Promise<boolean> => {
   return prismaInstance.$transaction(async (tx) => {
     const buildInfoAlreadyExists = (await tx.imageBuildInfo.count({
       where: {
-        dockerfileSHA: dockerfileSHASum,
-        dockerfileContent: dockerfileContents,
-        responseURL
+        dockerfileSHA: dockerfile_sha_sum,
       }
     })) > 0;
     if (buildInfoAlreadyExists) {
@@ -15,9 +13,10 @@ const enqueueImageBuild = ({ dockerfileSHASum, dockerfileContents, responseURL }
     } else {
       await tx.imageBuildInfo.create({
         data: {
-          dockerfileSHA: dockerfileSHASum,
-          dockerfileContent: dockerfileContents,
-          responseURL
+          dockerfileSHA: dockerfile_sha_sum,
+          dockerfileContent: dockerfile_contents,
+          responseURL: response_url,
+          buildKey: build_key
         }
       });
       return true;

--- a/orchestrator/packages/image-build-service/src/process-request/__tests__/image-creation.test.ts
+++ b/orchestrator/packages/image-build-service/src/process-request/__tests__/image-creation.test.ts
@@ -7,9 +7,9 @@ const CONFIG = getConfig();
 
 describe("grader image functionality", () => {
   const graderImageBuildReq: GraderImageBuildRequest = {
-    dockerfileContents: `FROM hello-world
-    `,
+    dockerfileContents: `FROM hello-world`,
     dockerfileSHASum: "generated-sha-sum",
+    responseURL: "http://example.com/response"
   };
 
   beforeAll(() => {

--- a/orchestrator/packages/image-build-service/src/process-request/__tests__/image-creation.test.ts
+++ b/orchestrator/packages/image-build-service/src/process-request/__tests__/image-creation.test.ts
@@ -7,9 +7,10 @@ const CONFIG = getConfig();
 
 describe("grader image functionality", () => {
   const graderImageBuildReq: GraderImageBuildRequest = {
-    dockerfileContents: `FROM hello-world`,
-    dockerfileSHASum: "generated-sha-sum",
-    responseURL: "http://example.com/response"
+    dockerfile_contents: `FROM hello-world`,
+    dockerfile_sha_sum: "generated-sha-sum",
+    response_url: "http://example.com/response",
+    build_key: "{\"grader_id\": 1}"
   };
 
   beforeAll(() => {
@@ -22,7 +23,7 @@ describe("grader image functionality", () => {
     rmSync(
       path.join(
         CONFIG.dockerImageFolder,
-        `${graderImageBuildReq.dockerfileSHASum}.tgz`,
+        `${graderImageBuildReq.dockerfile_sha_sum}.tgz`,
       ),
       {
         force: true,
@@ -37,7 +38,7 @@ describe("grader image functionality", () => {
       existsSync(
         path.join(
           CONFIG.dockerImageFolder,
-          `${graderImageBuildReq.dockerfileSHASum}.Dockerfile`,
+          `${graderImageBuildReq.dockerfile_sha_sum}.Dockerfile`,
         ),
       ),
     ).toBe(false);
@@ -46,7 +47,7 @@ describe("grader image functionality", () => {
         path.join(
           path.join(
             CONFIG.dockerImageFolder,
-            `${graderImageBuildReq.dockerfileSHASum}.tgz`,
+            `${graderImageBuildReq.dockerfile_sha_sum}.tgz`,
           ),
         ),
       ),

--- a/orchestrator/packages/image-build-service/src/process-request/image-creation.ts
+++ b/orchestrator/packages/image-build-service/src/process-request/image-creation.ts
@@ -1,7 +1,6 @@
-import { GraderImageBuildRequest, getConfig } from "@codegrade-orca/common";
+import { GraderImageBuildRequest, ImageBuildFailure, ImageBuildLog, getConfig } from "@codegrade-orca/common";
 import { execFile } from "child_process";
-import { writeFile } from "fs";
-import { rm } from "fs/promises";
+import { writeFile, rm } from "fs";
 import path from "path";
 
 const CONFIG = getConfig();
@@ -9,32 +8,34 @@ const CONFIG = getConfig();
 export const createAndStoreGraderImage = (
   buildRequest: GraderImageBuildRequest,
 ) => {
-  // TODO: validate dockerfileContent
-  return writeDockerfileContentsToFile(buildRequest)
-    .then((_) => buildImage(buildRequest))
+  const buildLogs: Array<ImageBuildLog> = [];
+  return writeDockerfileContentsToFile(buildRequest, buildLogs)
+    .then((_) => buildImage(buildRequest, buildLogs))
     .then((_) =>
-      rm(
-        path.join(
-          CONFIG.dockerImageFolder,
-          `${buildRequest.dockerfileSHASum}.Dockerfile`,
-        ),
-      ),
-    )
-    .then((_) => saveImageToTgz(buildRequest.dockerfileSHASum));
+      removeDockerfileAfterBuild(
+        path.join(CONFIG.dockerImageFolder, `${buildRequest.dockerfileSHASum}.Dockerfile`),
+        buildLogs
+      ))
+    .then((_) => saveImageToTgz(buildRequest.dockerfileSHASum, buildLogs));
 };
 
-const writeDockerfileContentsToFile = ({
-  dockerfileContents,
-  dockerfileSHASum,
-}: GraderImageBuildRequest): Promise<string> => {
+const writeDockerfileContentsToFile = ({ dockerfileContents, dockerfileSHASum }: GraderImageBuildRequest, buildLogs: Array<ImageBuildLog>): Promise<string> => {
   return new Promise((resolve, reject) => {
     const dockerfilePath = path.join(
       CONFIG.dockerImageFolder,
       `${dockerfileSHASum}.Dockerfile`,
     );
     writeFile(dockerfilePath, dockerfileContents, (err) => {
+      buildLogs.push({
+        step: "Write request contents to Dockerfile.",
+        stderr: ""
+      });
       if (err) {
-        reject(err);
+        const buildFailure: ImageBuildFailure = {
+          logs: buildLogs,
+          error: err
+        };
+        reject(buildFailure);
       } else {
         resolve(dockerfilePath);
       }
@@ -42,23 +43,31 @@ const writeDockerfileContentsToFile = ({
   });
 };
 
-const buildImage = ({
-  dockerfileSHASum,
-}: GraderImageBuildRequest): Promise<void> => {
+const buildImage = ({ dockerfileSHASum }: GraderImageBuildRequest, buildLogs: Array<ImageBuildLog>): Promise<void> => {
+  const dockerBuildArgs = [
+    "build",
+    "-t",
+    dockerfileSHASum,
+    "-f",
+    path.join(CONFIG.dockerImageFolder, `${dockerfileSHASum}.Dockerfile`),
+    ".",
+  ];
   return new Promise<void>((resolve, reject) => {
     execFile(
       "docker",
-      [
-        "build",
-        "-t",
-        dockerfileSHASum,
-        "-f",
-        path.join(CONFIG.dockerImageFolder, `${dockerfileSHASum}.Dockerfile`),
-        ".",
-      ],
-      (err, _stdout, _stderr) => {
+      dockerBuildArgs,
+      (err, _stdout, stderr) => {
+        buildLogs.push({
+          step: "Run docker build on Dockerfile.",
+          cmd: ["docker", ...dockerBuildArgs],
+          stderr
+        });
         if (err) {
-          reject(err);
+          const buildFailure: ImageBuildFailure = {
+            error: err,
+            logs: buildLogs
+          };
+          reject(buildFailure);
         } else {
           resolve();
         }
@@ -67,19 +76,45 @@ const buildImage = ({
   });
 };
 
-const saveImageToTgz = (imageName: string): Promise<void> => {
+const removeDockerfileAfterBuild = (dockerfilePath: string, buildLogs: Array<ImageBuildLog>): Promise<void> => {
+  buildLogs.push({
+    stderr: "",
+    step: "Remove residual Dockerfile."
+  });
+  return new Promise<void>((resolve, reject) => {
+    rm(dockerfilePath, (err) => {
+      if (err) {
+        const buildFailure: ImageBuildFailure = { error: err, logs: buildLogs };
+        reject(buildFailure);
+      } else {
+        resolve();
+      }
+    })
+  });
+};
+
+const saveImageToTgz = (imageName: string, buildLogs: Array<ImageBuildLog>): Promise<void> => {
+  const dockerSaveCommandArgs = [
+    "save",
+    "-o",
+    path.join(CONFIG.dockerImageFolder, `${imageName}.tgz`),
+    imageName,
+  ];
   return new Promise<void>((resolve, reject) => {
     execFile(
       "docker",
-      [
-        "save",
-        "-o",
-        path.join(CONFIG.dockerImageFolder, `${imageName}.tgz`),
-        imageName,
-      ],
-      (err, _stdout, _stderr) => {
+      dockerSaveCommandArgs,
+      (err, _stdout, stderr) => {
         if (err) {
-          reject(err);
+          const buildFailure: ImageBuildFailure = {
+            error: err,
+            logs: [...buildLogs, {
+              step: "Save image to .tgz file.",
+              cmd: ["docker", ...dockerSaveCommandArgs],
+              stderr
+            }],
+          };
+          reject(buildFailure);
         } else {
           resolve();
         }

--- a/orchestrator/packages/image-build-service/src/process-request/image-creation.ts
+++ b/orchestrator/packages/image-build-service/src/process-request/image-creation.ts
@@ -73,9 +73,11 @@ const buildImage = ({ dockerfile_sha_sum }: GraderImageBuildRequest, buildLogs: 
             logs: buildLogs
           });
         } else {
+          // All docker build information, regardless of status code,
+          // is logged to STDERR.
           buildLogs.push({
             step,
-            output: stdout
+            output: stderr
           });
           resolve();
         }

--- a/orchestrator/packages/image-build-service/src/process-request/index.ts
+++ b/orchestrator/packages/image-build-service/src/process-request/index.ts
@@ -2,7 +2,6 @@ import path from "path";
 import {
   getConfig,
 } from "@codegrade-orca/common";
-import { } from "@codegrade-orca/db";
 import { readdir, rm, stat } from "fs/promises";
 
 const CONFIG = getConfig();

--- a/orchestrator/packages/image-build-service/src/utils.ts
+++ b/orchestrator/packages/image-build-service/src/utils.ts
@@ -1,4 +1,4 @@
-import { GraderImageBuildRequest, GraderImageBuildResult, GradingJobResult, ImageBuildFailure, getConfig } from "@codegrade-orca/common";
+import { GraderImageBuildRequest, GraderImageBuildResult, GradingJobResult, getConfig } from "@codegrade-orca/common";
 import { CancelJobInfo } from "@codegrade-orca/db/dist/image-builder-operations/handle-completed-image-build";
 import { execFile } from "child_process";
 import { existsSync, rmSync } from "fs";
@@ -62,19 +62,17 @@ export const sendJobResultForBuildFail = async (cancelInfo: CancelJobInfo) => {
   });
 }
 
-export const notifyClientOfBuildFail = async (buildFailure: ImageBuildFailure, originalReq: GraderImageBuildRequest)  => {
-  const result: GraderImageBuildResult = {
-    build_logs: buildFailure.logs,
-    server_exception: buildFailure.error.toString(),
-    was_successful: false,
-    dockerfile_sha_sum: originalReq.dockerfileSHASum
-  };
-  await fetch(originalReq.responseURL, {
+export const notifyClientOfBuildFail = async (buildFailure: GraderImageBuildResult, originalReq: GraderImageBuildRequest) => {
+  const { response_url, build_key } = originalReq;
+  await fetch(response_url, {
     method: "POST",
     headers: {
       "Accept": "application/json",
       "Content-Type": "application/json"
     },
-    body: JSON.stringify(result)
+    body: JSON.stringify({
+      ...buildFailure,
+      build_key
+    })
   });
 }

--- a/orchestrator/packages/image-build-service/src/utils.ts
+++ b/orchestrator/packages/image-build-service/src/utils.ts
@@ -62,7 +62,7 @@ export const sendJobResultForBuildFail = async (cancelInfo: CancelJobInfo) => {
   });
 }
 
-export const notifyClientOfBuildFail = async (buildFailure: GraderImageBuildResult, originalReq: GraderImageBuildRequest) => {
+export const notifyClientOfBuildResult = async (result: GraderImageBuildResult, originalReq: GraderImageBuildRequest) => {
   const { response_url, build_key } = originalReq;
   await fetch(response_url, {
     method: "POST",
@@ -71,7 +71,7 @@ export const notifyClientOfBuildFail = async (buildFailure: GraderImageBuildResu
       "Content-Type": "application/json"
     },
     body: JSON.stringify({
-      ...buildFailure,
+      ...result,
       build_key
     })
   });

--- a/worker/images/testing/echo-server/index.js
+++ b/worker/images/testing/echo-server/index.js
@@ -24,10 +24,10 @@ app.get("/job-output/:key", (req, res) => {
 });
 
 app.post("/job-output", (req, res) => {
-  const { key, output } = req.body;
+  const { key, build_key } = req.body;
   console.log(req.body);
-  if (key) {
-    responses[key] = req.body;
+  if (key || build_key) {
+    responses[key || build_key] = req.body;
     return res.sendStatus(200);
   }
   res.sendStatus(400);

--- a/worker/orca_grader/common/grading_job/grading_job_result.py
+++ b/worker/orca_grader/common/grading_job/grading_job_result.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 from orca_grader.container.grading_script.grading_script_command_response import GradingScriptCommandResponse
-from orca_grader.common.types.grading_job_json_types import GradingJobResultJSON, GradingJobResultJSON
+from orca_grader.common.types.grading_job_json_types import GradingJobResultJSON
 
 
 class GradingJobResult:

--- a/worker/orca_grader/common/grading_job/grading_job_result.py
+++ b/worker/orca_grader/common/grading_job/grading_job_result.py
@@ -1,31 +1,38 @@
 from typing import List, Optional
 from orca_grader.container.grading_script.grading_script_command_response import GradingScriptCommandResponse
-from orca_grader.common.types.grading_job_json_types import GradingJobOutputJSON, GradingJobOutputJSON
+from orca_grader.common.types.grading_job_json_types import GradingJobResultJSON, GradingJobResultJSON
+
 
 class GradingJobResult:
-  
-  def __init__(self, command_responses: List[GradingScriptCommandResponse],
-               execution_errors: List[Exception] = [],
-               output: str = None) -> None:
-    self.__command_responses = command_responses
-    self.__execution_errors = execution_errors
-    self.__output = output
-  
-  def get_command_responses(self) -> List[GradingScriptCommandResponse]:
-    return self.__command_responses
-  
-  def get_output(self) -> Optional[str]:
-    return self.__output
-  
-  def get_execution_errors(self) -> List[Exception]:
-    return self.__execution_errors
-  
-  def to_json(self) -> GradingJobOutputJSON:
-    result = dict()
-    json_responses = list(map(lambda c: c.to_json(), self.__command_responses))
-    result["shell_responses"] = json_responses
-    if self.__execution_errors is not None:
-      result["errors"] = list(map(lambda e: f"{e.__class__.__name__}: {e}", self.__execution_errors))
-    if self.__output is not None:
-      result["output"] = self.__output
-    return result
+
+    def __init__(self, command_responses: List[GradingScriptCommandResponse],
+                 execution_errors: List[Exception] = [],
+                 output: str = None) -> None:
+        self.__command_responses = command_responses
+        self.__execution_errors = execution_errors
+        self.__output = output
+
+    def get_command_responses(self) -> List[GradingScriptCommandResponse]:
+        return self.__command_responses
+
+    def get_output(self) -> Optional[str]:
+        return self.__output
+
+    def get_execution_errors(self) -> List[Exception]:
+        return self.__execution_errors
+
+    def to_json(self) -> GradingJobResultJSON:
+        result = {"type": "GradingJobResult"}
+        json_responses = list(
+            map(lambda c: c.to_json(), self.__command_responses))
+        result["shell_responses"] = json_responses
+        if self.__execution_errors is not None:
+            result["errors"] = list(
+                map(
+                    lambda e: f"{e.__class__.__name__}: {e}",
+                    self.__execution_errors
+                )
+            )
+        if self.__output is not None:
+            result["output"] = self.__output
+        return result

--- a/worker/orca_grader/common/types/grading_job_json_types.py
+++ b/worker/orca_grader/common/types/grading_job_json_types.py
@@ -2,5 +2,5 @@ from typing import Any, Dict
 
 GradingJobJSON = Dict[Any, Any]
 GradingScriptCommandJSON = Dict[str, Any]
-GradingJobOutputJSON = Dict[str, Any]
+GradingJobResultJSON = Dict[str, Any]
 CodeFileInfoJSON = Dict[str, str]


### PR DESCRIPTION
## Feature/Problem Description
The client (aka, a job's creator) should be notified in the following scenarios:
* When someone has cancelled a job through the `deleteJob` endpoint.
* When an image has failed to build and a job config in the holding pen was not able to be enqueued.

## Solution (Changes Made)
* POST requests made to the response endpoint for a job with the `GradingJobResult` and the job's key.

