### PR TITLE
Fix: Validate `on_*` Keys Point to List of Commands

### DIFF
--- a/orchestrator/packages/common/src/validations/schemas/grading-job-config.ts
+++ b/orchestrator/packages/common/src/validations/schemas/grading-job-config.ts
@@ -56,7 +56,10 @@ const conditionalGradingScriptCommand = {
     on_true: {
       anyOf: [
         {
-          $ref: "https://orca-schemas.com/grading-job-config/grading-script-command",
+          type: "array",
+          items: {
+            $ref: "https://orca-schemas.com/grading-job-config/grading-script-command",
+          }
         },
         { type: "string" },
         { type: "number" },
@@ -65,7 +68,10 @@ const conditionalGradingScriptCommand = {
     on_false: {
       anyOf: [
         {
-          $ref: "https://orca-schemas.com/grading-job-config/grading-script-command",
+          type: "array",
+          items: {
+            $ref: "https://orca-schemas.com/grading-job-config/grading-script-command",
+          }
         },
         { type: "string" },
         { type: "number" },

--- a/worker/orca_grader/validations/schemas/bash_grading_script_command_schema.json
+++ b/worker/orca_grader/validations/schemas/bash_grading_script_command_schema.json
@@ -19,16 +19,30 @@
       "oneOf": [
         { "type": "string" },
         { "type": "number" },
-        { "$ref": "bash_grading_script_command_schema.json" },
-        { "$ref": "conditional_grading_script_comamnd_schema.json" }
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "$ref": "bash_grading_script_command_schema.json" },
+              { "$ref": "conditional_grading_script_comamnd_schema.json" }
+            ]
+          }
+        }
       ]
     },
     "on_fail": {
       "oneOf": [
         { "type": "string" },
         { "type": "number" },
-        { "$ref": "bash_grading_script_command_schema.json" },
-        { "$ref": "conditional_grading_script_comamnd_schema.json" }
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "$ref": "bash_grading_script_command_schema.json" },
+              { "$ref": "conditional_grading_script_comamnd_schema.json" }
+            ]
+          }
+        }
       ]
     },
     "timeout": { "type": "number" },


### PR DESCRIPTION
## Feature/Problem Description
The data definitions doc describes that the `on_*` key of any `GradingScriptCommand` may hold an `Array<GradingScriptCommand>`; however, we were actually checking for the key only having a _single_ command instead of this list in the actual `jsonschema` logic, which was incorrect.

## Solution (Changes Made)
* Update `jsonschema` logic in the orchestrator and worker to correctly check for the list of commands.


