### PR TITLE
Feature: API Key Auth for Mutation Routes

### DIFF
--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "private": "true",
   "scripts": {
+    "generate-api-key": "yarn workspace @codegrade-orca/db generate-api-key",
     "server": "yarn workspace @codegrade-orca/api start",
     "server:dev": "yarn workspace @codegrade-orca/api dev",
     "image-builder": "yarn workspace @codegrade-orca/image-build-service start",

--- a/orchestrator/packages/api/src/middleware/verify-api-key.ts
+++ b/orchestrator/packages/api/src/middleware/verify-api-key.ts
@@ -1,0 +1,15 @@
+import { validAPIKey } from "@codegrade-orca/db";
+import { Request, Response, NextFunction } from "express";
+
+const verifyAPIKey = async (req: Request, res: Response, next: NextFunction) => {
+  const apiKey = req.header("x-api-key");
+  if (!apiKey) {
+    return res.sendStatus(401);
+  }
+  if (await validAPIKey(req.hostname, apiKey)) {
+    next();
+  } else {
+    res.sendStatus(401);
+  }
+};
+export default verifyAPIKey;

--- a/orchestrator/packages/api/src/routes/docker-images.ts
+++ b/orchestrator/packages/api/src/routes/docker-images.ts
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { createGraderImage, getImageBuildStatus } from "../controllers/docker-image-controller";
+import verifyAPIKey from "../middleware/verify-api-key";
 
 const dockerImagesRouter = Router();
 
-dockerImagesRouter.post("/grader_images", createGraderImage);
+dockerImagesRouter.post("/grader_images", verifyAPIKey, createGraderImage);
 dockerImagesRouter.get("/grader_images/status/:dockerfileSHA", getImageBuildStatus);
 
 export default dockerImagesRouter;

--- a/orchestrator/packages/api/src/routes/grading-queue.ts
+++ b/orchestrator/packages/api/src/routes/grading-queue.ts
@@ -7,16 +7,16 @@ import {
   createOrUpdateImmediateJob,
   jobStatus,
 } from "../controllers/grading-queue-controller";
+import verifyAPIKey from "../middleware/verify-api-key";
 
 const gradingQueueRouter = Router();
 
 // TODO: Add middleware/move existing validation to middleware
 gradingQueueRouter.get("/grading_queue", getGradingJobs);
-gradingQueueRouter.put("/grading_queue", createOrUpdateJob);
-gradingQueueRouter.put("/grading_queue/immediate", createOrUpdateImmediateJob);
-gradingQueueRouter.put("/grading_queue/move", moveJob);
-gradingQueueRouter.delete("/grading_queue/:jobID", deleteJob);
-gradingQueueRouter.post("/grading_queue/job_status", jobStatus);
+gradingQueueRouter.put("/grading_queue", verifyAPIKey, createOrUpdateJob);
+gradingQueueRouter.put("/grading_queue/immediate", verifyAPIKey, createOrUpdateImmediateJob);
+gradingQueueRouter.put("/grading_queue/move", verifyAPIKey, moveJob);
+gradingQueueRouter.delete("/grading_queue/:jobID", verifyAPIKey, deleteJob);
 gradingQueueRouter.get("/grading_queue/:jobID/status", jobStatus);
 
 export default gradingQueueRouter;

--- a/orchestrator/packages/db/package.json
+++ b/orchestrator/packages/db/package.json
@@ -8,7 +8,8 @@
   "private": true,
   "scripts": {
     "build": "tsc --build",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "generate-api-key": "ts-node src/scripts/generate-api-key.ts"
   },
   "devDependencies": {
     "jest-mock-extended": "^3.0.5",

--- a/orchestrator/packages/db/prisma/migrations/20240802000935_init/migration.sql
+++ b/orchestrator/packages/db/prisma/migrations/20240802000935_init/migration.sql
@@ -57,6 +57,15 @@ CREATE TABLE "JobConfigAwaitingImage" (
     CONSTRAINT "JobConfigAwaitingImage_pkey" PRIMARY KEY ("id")
 );
 
+-- CreateTable
+CREATE TABLE "ApiKey" (
+    "id" SERIAL NOT NULL,
+    "hostname" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+
+    CONSTRAINT "ApiKey_pkey" PRIMARY KEY ("id")
+);
+
 -- CreateIndex
 CREATE UNIQUE INDEX "Reservation_jobID_key" ON "Reservation"("jobID");
 

--- a/orchestrator/packages/db/prisma/schema.prisma
+++ b/orchestrator/packages/db/prisma/schema.prisma
@@ -79,3 +79,9 @@ model JobConfigAwaitingImage {
 
   @@unique([clientKey, clientURL])
 }
+
+model ApiKey {
+  id Int @id @default(autoincrement())
+  hostname String
+  value String
+}

--- a/orchestrator/packages/db/src/api-key-operations/index.ts
+++ b/orchestrator/packages/db/src/api-key-operations/index.ts
@@ -1,0 +1,20 @@
+import prismaInstance from '../prisma-instance';
+
+const KEY_LENGTH = 64;
+
+export const createAPIKey = async (hostname: string): Promise<string> =>
+  await prismaInstance.$transaction(async (tx) => {
+    const key = generateKey();
+    await tx.apiKey.create({
+      data: {
+        hostname,
+        value: key
+      }
+    });
+    return key;
+  });
+
+export const validAPIKey = async (hostname: string, value: string) =>
+  Boolean(await prismaInstance.apiKey.count({ where: { hostname, value } }))
+
+const generateKey = (): string => [...Array(KEY_LENGTH)].map((_) => Math.floor(Math.random() * 16).toString(16)).join('');

--- a/orchestrator/packages/db/src/api-key-operations/index.ts
+++ b/orchestrator/packages/db/src/api-key-operations/index.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import prismaInstance from '../prisma-instance';
 
 const KEY_LENGTH = 64;
@@ -17,4 +18,4 @@ export const createAPIKey = async (hostname: string): Promise<string> =>
 export const validAPIKey = async (hostname: string, value: string) =>
   Boolean(await prismaInstance.apiKey.count({ where: { hostname, value } }))
 
-const generateKey = (): string => [...Array(KEY_LENGTH)].map((_) => Math.floor(Math.random() * 16).toString(16)).join('');
+const generateKey = (): string => randomBytes(KEY_LENGTH).toString('hex');

--- a/orchestrator/packages/db/src/index.ts
+++ b/orchestrator/packages/db/src/index.ts
@@ -2,3 +2,4 @@ export * from "./exceptions";
 export * from "./server-operations";
 export * from "./image-builder-operations";
 export * from "./shared";
+export * from "./api-key-operations";

--- a/orchestrator/packages/db/src/scripts/generate-api-key.ts
+++ b/orchestrator/packages/db/src/scripts/generate-api-key.ts
@@ -1,0 +1,14 @@
+import { parseArgs } from "util";
+import { createAPIKey } from "../api-key-operations";
+
+const main = async () => {
+  const { values } = parseArgs({ options: { hostname: { type: "string", short: "h" } } });
+  const { hostname } = values;
+  if (!hostname) {
+    console.error("Must provide hostname for api key generation with flag '-h'.");
+    process.exit(1);
+  }
+  await createAPIKey(hostname as string);
+}
+
+main();


### PR DESCRIPTION
## Feature/Problem Description
Clients of Orca should not be able to mutate the state of its workflow without proper authorization, here implemented in the form of API keys in a database.

## Solution (Changes Made)
* DB schema change to add ApiKey table.
* Operations for:
  * Validating api keys
  * Creating a new api key
* Script as part of `package.json` to run key creation task
* Middleware on API routes to validate api key in header 

