### PR TITLE
Refactor: More Informative Job Status

### DIFF
--- a/orchestrator/packages/api/src/controllers/grading-queue-controller.ts
+++ b/orchestrator/packages/api/src/controllers/grading-queue-controller.ts
@@ -191,8 +191,6 @@ export const jobStatus = async (req: Request, res: Response) => {
   const jobQueueStatus = await getJobStatus(jobID);
   if (!jobQueueStatus) {
     return res.json("We could not find the job you're looking for. Please contact a professor or admin.");
-  } else if (typeof jobQueueStatus === "string") {
-    return res.json(jobQueueStatus);
   }
   const { reservation, queuePosition } = jobQueueStatus;
   if (reservationWaitingOnRelease(reservation.releaseAt)) {

--- a/orchestrator/packages/api/src/controllers/grading-queue-controller.ts
+++ b/orchestrator/packages/api/src/controllers/grading-queue-controller.ts
@@ -115,8 +115,8 @@ export const createOrUpdateImmediateJob = async (
 
   try {
     // TODO: Return job id from db operation and in response obj
-    const jobID = await putJobInQueue(req.body, true);
-    return res.status(200).json({ message: "OK", jobID });
+    const status = await putJobInQueue(req.body, true);
+    return res.status(200).json({ message: "OK", status });
   } catch (error) {
     console.error(error);
     if (error instanceof GradingQueueOperationException) {
@@ -136,8 +136,8 @@ export const createOrUpdateJob = async (req: Request, res: Response) => {
 
   try {
     // TODO: Return job id from db operation and in response obj
-    const jobID = await putJobInQueue(req.body, false);
-    return res.status(200).json({ message: "OK", jobID });
+    const status = await putJobInQueue(req.body, false);
+    return res.status(200).json({ message: "OK", status });
   } catch (err) {
     console.error(err);
     if (err instanceof GradingQueueOperationException) {

--- a/orchestrator/packages/api/src/controllers/holding-pen-controller.ts
+++ b/orchestrator/packages/api/src/controllers/holding-pen-controller.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from "express";
+import { errorResponse } from "./utils";
+import { jobConfigInHoldingPen } from "@codegrade-orca/db";
+
+export const holdingPenStatus = async (req: Request, res: Response) => {
+  const jobConfigID = parseInt(req.params.jobConfigID);
+  if (isNaN(jobConfigID)) {
+    return errorResponse(res, 400, [`Given job config ID ${jobConfigID} is not a number.`]);
+  }
+  if (await jobConfigInHoldingPen(jobConfigID)) {
+    res.json("This job is waiting of a grader image to build.");
+  } else {
+    res.json("This job could not be found in a holding pen. Please contact an admin or professor.");
+  }
+}

--- a/orchestrator/packages/api/src/index.ts
+++ b/orchestrator/packages/api/src/index.ts
@@ -5,6 +5,7 @@ import { getConfig } from "@codegrade-orca/common";
 import express = require("express");
 import cors = require("cors");
 import dockerImagesRouter from "./routes/docker-images";
+import holdingPenRouter from "./routes/holding-pen";
 
 const CONFIG = getConfig();
 
@@ -14,7 +15,7 @@ const PORT = process.env.PORT || 4000;
 app.use(cors());
 app.use(express.json());
 
-app.use("/api/v1", gradingQueueRouter, dockerImagesRouter);
+app.use("/api/v1", gradingQueueRouter, dockerImagesRouter, holdingPenRouter);
 app.use("/status", (_req, res) => res.json({"message": "ok"}));
 app.use("/images", express.static(CONFIG.dockerImageFolder));
 

--- a/orchestrator/packages/api/src/routes/holding-pen.ts
+++ b/orchestrator/packages/api/src/routes/holding-pen.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { holdingPenStatus } from "../controllers/holding-pen-controller";
+
+const holdingPenRouter = Router();
+
+holdingPenRouter.get("/holding_pen/:jobConfigID/status", holdingPenStatus);
+
+export default holdingPenRouter;

--- a/orchestrator/packages/common/src/index.ts
+++ b/orchestrator/packages/common/src/index.ts
@@ -6,6 +6,7 @@ import { existsSync } from "fs";
 export * from "./grading-jobs";
 export * from "./types";
 export * from "./config";
+export * from "./utils";
 export { validations };
 
 export const toMilliseconds = (seconds: number) => seconds * 1_000;

--- a/orchestrator/packages/common/src/types/index.ts
+++ b/orchestrator/packages/common/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./grading-queue";
 export * from "./image-build-service";
 export * from "./job-result";
+export * from "./job-status";

--- a/orchestrator/packages/common/src/types/job-status.ts
+++ b/orchestrator/packages/common/src/types/job-status.ts
@@ -1,0 +1,4 @@
+export interface JobStatus {
+  location: "HoldingPen" | "Queue",
+  id: number,
+};

--- a/orchestrator/packages/common/src/utils/index.ts
+++ b/orchestrator/packages/common/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './push-status-update';

--- a/orchestrator/packages/common/src/utils/push-status-update.ts
+++ b/orchestrator/packages/common/src/utils/push-status-update.ts
@@ -1,0 +1,12 @@
+import { JobStatus } from "../types";
+
+export const pushStatusUpdate = async (status: JobStatus, responseURL: string, key: string): Promise<void> => {
+  // NOTE: This is meant to be 'fire-and-forget,' -- we don't care about errors
+  // beyond logging.
+  try {
+    const body = JSON.stringify({ key, status });
+    await fetch(responseURL, { body, method: 'POST', headers: { 'Content-Type': 'application/json' } });
+  } catch (err) {
+    console.error(`Could not POST status update to ${responseURL}; ${err instanceof Error ? err.message : err}`);
+  }
+};

--- a/orchestrator/packages/db/src/holding-pen-operations/index.ts
+++ b/orchestrator/packages/db/src/holding-pen-operations/index.ts
@@ -1,0 +1,4 @@
+import prismaInstance from '../prisma-instance';
+
+export const jobConfigInHoldingPen = async (jobConfigID: number): Promise<boolean> =>
+  Boolean(await prismaInstance.jobConfigAwaitingImage.count({ where: { id: jobConfigID } }));

--- a/orchestrator/packages/db/src/index.ts
+++ b/orchestrator/packages/db/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./exceptions";
 export * from "./server-operations";
 export * from "./image-builder-operations";
+export * from "./holding-pen-operations";
 export * from "./shared";

--- a/orchestrator/packages/db/src/server-operations/job-queue-status.ts
+++ b/orchestrator/packages/db/src/server-operations/job-queue-status.ts
@@ -8,17 +8,14 @@ export interface JobQueueStatus {
   queuePosition: number
 }
 
-const getJobStatus = async (jobID: number): Promise<JobQueueStatus | string | null> =>
+const getJobStatus = async (jobID: number): Promise<JobQueueStatus | null> =>
   prismaInstance.$transaction(async (tx) => {
     const job = await tx.job.findFirst({
       where: { id: jobID },
       include: { reservation: true }
     });
     if (!job) {
-      const jobInHoldingPen = Boolean(await tx.jobConfigAwaitingImage.count(
-        { where: { id: jobID } }
-      ));
-      return jobInHoldingPen ? "This job is waiting on its grader image to be built." : null;
+      return null;
     }
     const reservation: Reservation = job.reservation || await getAssociatedReservation(job, tx);
     return {

--- a/worker/orca_grader/common/services/push_status.py
+++ b/worker/orca_grader/common/services/push_status.py
@@ -8,6 +8,12 @@ def post_job_status_to_client(location: str, response_url: str,
         status = {"location": location}
         if id is not None:
             status["id"] = id
-        requests.post(response_url, json=status)
+        requests.post(
+            response_url,
+            json={"key": key, "status": status}
+        ).raise_for_status()
+    except requests.HTTPError as http_e:
+        print(http_e)
+        print(f"{http_e.request.body}, {http_e.request.headers}")
     except Exception as e:
         print(e)

--- a/worker/orca_grader/common/services/push_status.py
+++ b/worker/orca_grader/common/services/push_status.py
@@ -1,0 +1,13 @@
+import requests
+from typing import Optional
+
+
+def post_job_status_to_client(location: str, response_url: str,
+                              key: str, id: Optional[int] = None) -> None:
+    try:
+        status = {"location": location}
+        if id is not None:
+            status["id"] = id
+        requests.post(response_url, json=status)
+    except Exception as e:
+        print(e)

--- a/worker/orca_grader/db/operations.py
+++ b/worker/orca_grader/db/operations.py
@@ -67,10 +67,10 @@ def reenqueue_job(grading_job: GradingJobJSON):
                 grading_job["client_url"]
             )
             __delete_more_recent_job_queue_info(session, more_recent_job)
-            __create_immediate_job(session, {**grading_job,
+            return __create_immediate_job(session, {**grading_job,
                                              **more_recent_job.config})
         else:
-            __create_immediate_job(session, grading_job)
+            return __create_immediate_job(session, grading_job)
 
 
 def __create_immediate_job(session: Session, grading_job: GradingJobJSON):
@@ -88,6 +88,7 @@ def __create_immediate_job(session: Session, grading_job: GradingJobJSON):
         insert(Reservation)
         .values(job_id=inserted_job_id, release_at=grading_job["release_at"])
     )
+    return inserted_job_id
 
 
 def __omit(d: Dict[str, Any], keys: Set[str]) -> Dict[str, Any]:

--- a/worker/orca_grader/job_retrieval/postgres/grading_job_retriever.py
+++ b/worker/orca_grader/job_retrieval/postgres/grading_job_retriever.py
@@ -4,7 +4,7 @@ from orca_grader.db.operations import get_next_job
 from orca_grader.job_retrieval.grading_job_retriever import GradingJobRetriever
 
 
-class PostgresGradingJobRetirever(GradingJobRetriever):
+class PostgresGradingJobRetriever(GradingJobRetriever):
 
     def retrieve_grading_job(self) -> Optional[GradingJobJSON]:
         return get_next_job()


### PR DESCRIPTION
## Feature/Problem Description
Orca clients need to know which _specific_ state a given job is in -- more specifically, one of the following:
* Waiting for a grader to be built.
* In the queue.
* Being graded by a worker.

Previously, we only handled the first case.

## Solution (Changes Made)
* New type `JobStatus` that details the location of the job in the Orca pipeline and what its DB ID is (if applicable).
* New endpoint for the holding pen to determine if a job is being held while a grader is being built.
* New request sent from worker to client informing it that it has picked up a given job.


