### PR TITLE
Fixes: Orchestrator Logging, Worker Sleep, Polyfill/GroupBy

### DIFF
--- a/orchestrator/packages/common/src/__tests__/logger.test.ts
+++ b/orchestrator/packages/common/src/__tests__/logger.test.ts
@@ -1,0 +1,34 @@
+import path from 'path';
+import { OrchestratorConfig } from '../config';
+import { existsSync, rmSync } from 'fs';
+
+const logsDirForTesting = path.join(__dirname, 'logs');
+const mockConfig: OrchestratorConfig = {
+  postgresURL: 'url',
+  environment: 'development',
+  dockerImageFolder: 'dir',
+  orchestratorLogsDir: logsDirForTesting,
+  api: {}
+};
+jest.mock('../config', () => ({
+  getConfig: jest.fn().mockReturnValue(mockConfig)
+}));
+jest.mock('pino');
+
+beforeAll(() => {
+  expect(existsSync(logsDirForTesting)).toBe(false);
+});
+
+afterAll(() => {
+  if (existsSync(logsDirForTesting)) {
+    rmSync(logsDirForTesting, { recursive: true, force: true });
+  }
+});
+
+describe('orchestrator logger', () => {
+  it("creates a directory upon being used", () => {
+    import('../logger').then(({ default: _logger }) => {
+      expect(existsSync(logsDirForTesting)).toBe(true);
+    });
+  });
+});

--- a/orchestrator/packages/common/src/config.ts
+++ b/orchestrator/packages/common/src/config.ts
@@ -5,6 +5,7 @@ export interface OrchestratorConfig {
   dockerImageFolder: string;
   postgresURL: string;
   environment: string;
+  orchestratorLogsDir?: string;
 }
 
 interface OrchestratorAPIOptions {
@@ -17,5 +18,6 @@ export const getConfig = (): OrchestratorConfig => ({
     port: process.env.API_PORT ? parseInt(process.env.API_PORT) : 8090,
   },
   dockerImageFolder: join(__dirname, "../../../", "images"),
-  environment: process.env.ENVIRONMENT?.toLowerCase() || 'dev'
+  environment: process.env.ENVIRONMENT?.toLowerCase() || 'dev',
+  orchestratorLogsDir: process.env.ORCHESTRATOR_LOG_DIR
 });

--- a/orchestrator/packages/common/src/logger.ts
+++ b/orchestrator/packages/common/src/logger.ts
@@ -1,26 +1,35 @@
 import pino from "pino";
 import { getConfig } from "./config";
 import path from "path";
+import { existsSync, mkdirSync } from "fs";
+
+const _CONFIG = getConfig();
+
+const pinoTarget = {
+  target: 'pino/file',
+  options: {
+    destination: _CONFIG.orchestratorLogsDir ?
+      path.join(_CONFIG.orchestratorLogsDir, `${_CONFIG.environment}.log`) :
+      1 // used by pino for STDOUT
+  }
+}
 
 const transport = pino.transport({
   targets: [
-    {
-      target: 'pino/file',
-      options: {
-        destination: path.join(__dirname, '../../../', 'logs', `${getConfig().environment}.log`),
-        mkdir: true
-      }
-    },
-    {
-      target: 'pino/file',
-      options: { destination: 2 }
-    }
+    pinoTarget
   ]
 });
 
-const logger = pino({
-  level: getConfig().environment === 'production' ? 'info' : 'debug',
-  timestamp: true,
-}, transport);
+const getLogger = () => {
+  if (_CONFIG.orchestratorLogsDir && !existsSync(_CONFIG.orchestratorLogsDir)) {
+    mkdirSync(_CONFIG.orchestratorLogsDir);
+  }
+  return pino({
+    level: getConfig().environment === 'production' ? 'info' : 'debug',
+    timestamp: true,
+  }, transport)
+}
+
+const logger = getLogger();
 
 export default logger;

--- a/orchestrator/packages/common/src/logger.ts
+++ b/orchestrator/packages/common/src/logger.ts
@@ -22,7 +22,7 @@ const transport = pino.transport({
 
 const getLogger = () => {
   if (_CONFIG.orchestratorLogsDir && !existsSync(_CONFIG.orchestratorLogsDir)) {
-    mkdirSync(_CONFIG.orchestratorLogsDir);
+    mkdirSync(_CONFIG.orchestratorLogsDir, { recursive: true });
   }
   return pino({
     level: getConfig().environment === 'production' ? 'info' : 'debug',

--- a/orchestrator/packages/common/src/utils/groupBy.ts
+++ b/orchestrator/packages/common/src/utils/groupBy.ts
@@ -1,0 +1,15 @@
+const groupBy = <T, U>(arr: Array<T>, callbackFn: (arg0: T, arg1: number) => U): Map<U, Array<T>> => {
+  const result: Map<U, Array<T>> = new Map();
+  for (let i = 0; i < arr.length; ++i) {
+    const v = arr[i];
+    const key = callbackFn(v, i);
+    if (result.has(key)) {
+      result.get(key)!.push(v);
+    } else {
+      result.set(key, [v]);
+    }
+  }
+  return result;
+};
+
+export default groupBy;

--- a/orchestrator/packages/common/src/utils/index.ts
+++ b/orchestrator/packages/common/src/utils/index.ts
@@ -1,4 +1,5 @@
 import graderImageExists from './grader-image-exists';
+import groupBy from './groupBy';
 
 export * from './push-status-update';
-export { graderImageExists };
+export { graderImageExists, groupBy };

--- a/worker/orca_grader/__main__.py
+++ b/worker/orca_grader/__main__.py
@@ -28,6 +28,7 @@ from orca_grader.common.services.push_status import post_job_status_to_client
 
 CONTAINER_WORKING_DIR = '/home/orca-grader'
 _LOGGER = logging.getLogger(__name__)
+_SLEEP_LENGTH = 5  # seconds
 
 
 def run_local_job(job_path: str, no_container: bool,
@@ -65,11 +66,12 @@ def process_jobs_from_db(no_container: bool,
                 if job_retrieval_future in done:
                     if job_retrieval_future.exception():
                         _LOGGER.exception("Failed to retrieve grading job from postgres.")
-                        time.sleep(1)
+                        time.sleep(_SLEEP_LENGTH)
                         continue
                     grading_job = job_retrieval_future.result()
                     if grading_job is None:
-                        time.sleep(1)
+                        _LOGGER.debug(f"No jobs on the queue; sleeping for {_SLEEP_LENGTH} seconds.")
+                        time.sleep(_SLEEP_LENGTH)
                         continue
 
                 if stop_future in done:


### PR DESCRIPTION
## Feature/Problem Description
Two major issues were encountered during initial attempts at deploying Orca:
1. Attempting to run the Orchestrator would fail if the directory did not exist for where to save logs
2. The `sleep` period when the Worker is waiting on a job is too short, creating a short _wait-and-burn_ period.


## Solution (Changes Made)
* Orchestrator logs directory is now based on an environment variable `ORCHESTRATOR_LOGS_DIR`.
  * If it is not provided, logs output will go directly to STDOUT.
* Sleep period when unable to pull a job off the queue is now 5 seconds.

