### PR TITLE
Fix: Worker Logging

### DIFF
--- a/worker/orca_grader/__main__.py
+++ b/worker/orca_grader/__main__.py
@@ -168,7 +168,7 @@ def handle_grading_job(grading_job: GradingJobJSON, container_sha: str | None = 
             # Allows for new code written to the orca_grader.container
             # module to be automatically picked up while running
             # during development.
-            if APP_CONFIG.environment == "dev":
+            if APP_CONFIG.environment == "development":
                 builder.add_docker_volume_mapping(
                     "./orca_grader",
                     os.path.join(CONTAINER_WORKING_DIR, "orca_grader")
@@ -199,7 +199,7 @@ def can_execute_job(grading_job: GradingJobJSON) -> bool:
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG if APP_CONFIG.environment == 'dev'
+    logging.basicConfig(level=logging.DEBUG if APP_CONFIG.environment == 'development'
                         else logging.INFO,
                         format='%(asctime)s - %(levelname)s - %(message)s',
                         handlers=[

--- a/worker/orca_grader/__main__.py
+++ b/worker/orca_grader/__main__.py
@@ -87,7 +87,9 @@ def process_jobs_from_db(no_container: bool,
                 )
 
                 job_execution_future = futures_executor.submit(
-                    run_grading_job, grading_job, no_container, container_command)
+                    run_grading_job, grading_job,
+                    no_container, container_command
+                )
                 done, not_done = concurrent.futures.wait(
                     [stop_future, job_execution_future], return_when="FIRST_COMPLETED")
                 # States of job and stop future after wait
@@ -133,9 +135,12 @@ def run_grading_job(grading_job: GradingJobJSON, no_container: bool,
         else:
             handle_grading_job(grading_job, container_sha)
     except Exception as e:
-        _LOGGER.debug(e)
         if isinstance(e, CalledProcessError):
-            _LOGGER.debug("STDERR output of subprocess: {e.stderr}")
+            _LOGGER.warning(f"STDERR output of subprocess: {e.stderr.decode()}")
+        else:
+            _LOGGER.warning(
+                f"Encountered error while trying to run this job: {e}"
+            )
         push_results_with_exception(grading_job, e)
 
 
@@ -161,10 +166,19 @@ def handle_grading_job(grading_job: GradingJobJSON, container_sha: str | None = 
             builder.add_docker_volume_mapping(
                 temp_job_file.name, container_job_path
             )
-            builder.add_docker_volume_mapping(
-                os.path.abspath(APP_CONFIG.logging_filepath),
-                os.path.join(CONTAINER_WORKING_DIR, APP_CONFIG.logging_filepath)
-            )
+            if logging_filepath() is not None:
+                log_file_name = os.path.basename(logging_filepath)
+                container_log_path = os.path.join(CONTAINER_WORKING_DIR,
+                                                  log_file_name)
+                builder.add_docker_volume_mapping(
+                    os.path.abspath(APP_CONFIG.logging_filepath),
+                    os.path.join(CONTAINER_WORKING_DIR, APP_CONFIG.logging_filepath)
+                )
+                builder.add_docker_environment_variable_mapping(
+                    "CONTAINER_LOG_FILE_PATH",
+                    container_log_path
+                )
+
             # Allows for new code written to the orca_grader.container
             # module to be automatically picked up while running
             # during development.
@@ -178,10 +192,14 @@ def handle_grading_job(grading_job: GradingJobJSON, container_sha: str | None = 
             builder = GradingJobExecutorBuilder(file_name)
         executor = builder.build()
         result = executor.execute()
-        if result and result.stdout:
-            print(result.stdout.decode(), file=sys.stderr)
-        if result and result.stderr:
-            print(result.stderr.decode(), file=sys.stderr)
+        # Because the docker container is running in a subprocess
+        # and we are capturing the STDOUT and STDERR, we need to
+        # explicitly write their to STDOUT (with no formatting; hence
+        # the print call) if we want to see logs display in the terminal.
+        if result and result.stdout and logging_filepath() is None:
+            print(result.stdout.decode())
+        if result and result.stderr and logging_filepath() is None:
+            print(result.stderr.decode())
 
 
 def inform_client_of_reenqueue(grading_job: GradingJobJSON,
@@ -198,14 +216,26 @@ def can_execute_job(grading_job: GradingJobJSON) -> bool:
         return False
 
 
+def logging_filepath() -> Optional[str]:
+    if APP_CONFIG.worker_logs_dir is not None:
+        return os.path.join(APP_CONFIG.worker_logs_dir,
+                            f"{APP_CONFIG.environment}.log")
+    else:
+        return None
+
+
 if __name__ == "__main__":
+    if APP_CONFIG.worker_logs_dir is not None:
+        if not os.path.isdir(APP_CONFIG.worker_logs_dir):
+            os.makedirs(APP_CONFIG.worker_logs_dir)
+        handler = logging.FileHandler(filename=logging_filepath())
+    else:
+        handler = logging.StreamHandler(stream=sys.stdout)
+
     logging.basicConfig(level=logging.DEBUG if APP_CONFIG.environment == 'development'
                         else logging.INFO,
                         format='%(asctime)s - %(levelname)s - %(message)s',
-                        handlers=[
-                          logging.FileHandler(filename=APP_CONFIG.logging_filepath),
-                          logging.StreamHandler()
-                        ])
+                        handlers=[handler])
     arg_parser = argparse.ArgumentParser(
         prog="Orca Grader",
         description="Pulls a job from a Redis queue and executes a script to autograde."

--- a/worker/orca_grader/common/services/push_results.py
+++ b/worker/orca_grader/common/services/push_results.py
@@ -27,6 +27,7 @@ def push_results_to_response_url(job_result: GradingJobResult,
 
 def push_results_with_exception(grading_job: GradingJobJSON,
                                 e: Exception) -> None:
+    _LOGGER.debug(e)
     output = GradingJobResult([], [e])
     key, response_url = grading_job["key"], grading_job["response_url"]
     push_results_to_response_url(output, key, response_url, {})
@@ -48,6 +49,8 @@ def _send_results_with_exponential_backoff(payload: dict, response_url: str, n: 
             raise PushResultsFailureException
         time.sleep(2**n + (random.randint(0, 1000) / 1000.0))
         return _send_results_with_exponential_backoff(payload, response_url, n + 1)
+    except Exception as e:
+        _LOGGER.error(f"Encountered the following error pushing results: {e}")
 
 
 def _should_retry(status_code: int) -> bool:

--- a/worker/orca_grader/config.py
+++ b/worker/orca_grader/config.py
@@ -17,6 +17,7 @@ class AppConfig():
         enable_diagnostics_val = os.getenv('ENABLE_DIAGNOSTICS', '') or ""
         self.enable_diagnostics = enable_diagnostics_val.lower() == "true"
         self.environment = os.getenv("ENVIRONMENT", "DEVELOPMENT").lower()
-        self.logging_filepath = f"log/{self.environment}.log"
+        self.worker_logs_dir = os.getenv("WORKER_LOGS_DIR")
+
 
 APP_CONFIG = AppConfig()

--- a/worker/orca_grader/config.py
+++ b/worker/orca_grader/config.py
@@ -16,7 +16,7 @@ class AppConfig():
             .replace("postgresql", "postgresql+psycopg")
         enable_diagnostics_val = os.getenv('ENABLE_DIAGNOSTICS', '') or ""
         self.enable_diagnostics = enable_diagnostics_val.lower() == "true"
-        self.environment = os.getenv("ENVIRONMENT", "DEV").lower()
+        self.environment = os.getenv("ENVIRONMENT", "DEVELOPMENT").lower()
         self.logging_filepath = f"log/{self.environment}.log"
 
 APP_CONFIG = AppConfig()

--- a/worker/orca_grader/container/do_grading.py
+++ b/worker/orca_grader/container/do_grading.py
@@ -81,7 +81,7 @@ def cleanup(secret: str) -> None:
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG if APP_CONFIG.environment == 'dev'
+    logging.basicConfig(level=logging.DEBUG if APP_CONFIG.environment == 'development'
                         else logging.INFO,
                         format='%(asctime)s - %(levelname)s - %(message)s',
                         handlers=[

--- a/worker/orca_grader/container/do_grading.py
+++ b/worker/orca_grader/container/do_grading.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import shutil
 import traceback
 import logging
@@ -81,13 +82,17 @@ def cleanup(secret: str) -> None:
 
 
 if __name__ == "__main__":
+    # Separate container environment variable
+    # This file must exist prior to being set
+    # since it relies on an existing docker volume.
+    log_file_path = os.getenv("CONTAINER_LOG_FILE_PATH")
+    handler = logging.FileHandler(filename=log_file_path) if \
+        log_file_path is not None else logging.StreamHandler(stream=sys.stdout)
     logging.basicConfig(level=logging.DEBUG if APP_CONFIG.environment == 'development'
                         else logging.INFO,
                         format='%(asctime)s - %(levelname)s - %(message)s',
-                        handlers=[
-                          logging.FileHandler(filename=APP_CONFIG.logging_filepath),
-                          logging.StreamHandler()
-                        ])
+                        handlers=[handler])
+
     secret = GradingJobExecutionSecret.get_secret()
     try:
         file_name = os.getenv('GRADING_JOB_FILE_NAME', 'grading_job.json')


### PR DESCRIPTION
## Feature/Problem Description
The Worker must match the same functionality as the Orchestrator in terms of logging.

This means writing things to STDOUT if no logging directory is provided, otherwise writng to that directory and creating it if it does not already exist.

## Solution (Changes Made)
* Update environment name to match nomenclature with Orchestrator.
* Use `WORKER_LOGS_DIR` environment variable for optional file logging.
  * Otherwise use `stdout`
* If using `stdout`, `print` output of container subprocess so that its output appears in the running process. 
