### PR TITLE
Orchestrator Single API Port Source

### DIFF
--- a/orchestrator/packages/api/src/index.ts
+++ b/orchestrator/packages/api/src/index.ts
@@ -10,8 +10,6 @@ import holdingPenRouter from "./routes/holding-pen";
 const CONFIG = getConfig();
 
 const app: Express = express();
-const PORT = process.env.PORT || 4000;
-
 app.use(cors());
 app.use(express.json());
 
@@ -19,9 +17,9 @@ app.use("/api/v1", gradingQueueRouter, dockerImagesRouter, holdingPenRouter);
 app.use("/status", (_req, res) => res.json({"message": "ok"}));
 app.use("/images", express.static(CONFIG.dockerImageFolder));
 
-app.listen(PORT, () => {
+app.listen(CONFIG.api.port, () => {
   if (!existsSync(CONFIG.dockerImageFolder)) {
     mkdirSync(CONFIG.dockerImageFolder);
   }
-  logger.info(`Server listening on port ${PORT}`);
+  logger.info(`Server listening on port ${CONFIG.api.port}`);
 });

--- a/orchestrator/packages/common/src/__tests__/logger.test.ts
+++ b/orchestrator/packages/common/src/__tests__/logger.test.ts
@@ -8,7 +8,7 @@ const mockConfig: OrchestratorConfig = {
   environment: 'development',
   dockerImageFolder: 'dir',
   orchestratorLogsDir: logsDirForTesting,
-  api: {}
+  api: { port: 4000 }
 };
 jest.mock('../config', () => ({
   getConfig: jest.fn().mockReturnValue(mockConfig)

--- a/orchestrator/packages/common/src/config.ts
+++ b/orchestrator/packages/common/src/config.ts
@@ -9,13 +9,13 @@ export interface OrchestratorConfig {
 }
 
 interface OrchestratorAPIOptions {
-  port?: number;
+  port: number;
 }
 
 export const getConfig = (): OrchestratorConfig => ({
   postgresURL: process.env.POSTGRES_URL || "postgresql://localhost:5432",
   api: {
-    port: process.env.API_PORT ? parseInt(process.env.API_PORT) : 8090,
+    port: process.env.API_PORT ? parseInt(process.env.API_PORT) : 4000,
   },
   dockerImageFolder: join(__dirname, "../../../", "images"),
   environment: process.env.ENVIRONMENT?.toLowerCase() || 'dev',


### PR DESCRIPTION
## Feature/Problem Description
The Orchestrator was referencing two possible environment variables for its API port: `PORT` and `API_PORT` -- the latter of which was only referenced in the `Config` object.

## Solution (Changes Made)
* API pulls it's port number from the `Config` object now, which references the `API_PORT` env variable and defaults to 4000 if it is not set.
