### PR TITLE
Fix: Utilize `response_url` or `x-forwarded-for` for Hostname in API Key Middleware

### DIFF
--- a/orchestrator/packages/api/src/middleware/verify-api-key.ts
+++ b/orchestrator/packages/api/src/middleware/verify-api-key.ts
@@ -1,22 +1,23 @@
-import { logger } from "@codegrade-orca/common";
+import { getConfig, logger } from "@codegrade-orca/common";
 import { validAPIKey } from "@codegrade-orca/db";
 import { Request, Response, NextFunction } from "express";
 
 const verifyAPIKey = async (req: Request, res: Response, next: NextFunction) => {
   const apiKey = req.header("x-api-key");
-  const urlStr = req.body.response_url ?? req.header;
-  logger.info(`API Key: |${apiKey ?? 'None'}| URLString: |${urlStr ?? 'None'}|`);
-  if (!apiKey) {
-    return res.sendStatus(401);
-  }
+  const urlStr = req.body['response_url'] ?? req.header('x-forwarded-for');
   try {
-    const url = new URL(urlStr);
-    if (await validAPIKey(url.hostname, apiKey)) {
-      return next();
+    const hostname = getConfig().environment === 'production' ? hostnameHandler(urlStr) : req.hostname;
+    logger.info(`API Key: |${apiKey ?? 'None'}| Hostname: |${hostname}|`);
+    if (!apiKey) {
+      return res.sendStatus(401);
     }
+    return (await validAPIKey(hostname, apiKey)) ? next() : res.sendStatus(401);
   } catch (e) {
     logger.warn(`Error: while constructing url or validating key for ${apiKey} and ${urlStr}: ${e}`);
+    res.sendStatus(401);
   }
-  res.sendStatus(401);
 };
+
+const hostnameHandler = (urlStr: string) => new URL(urlStr).hostname;
+
 export default verifyAPIKey;

--- a/orchestrator/packages/api/src/middleware/verify-api-key.ts
+++ b/orchestrator/packages/api/src/middleware/verify-api-key.ts
@@ -15,7 +15,7 @@ const verifyAPIKey = async (req: Request, res: Response, next: NextFunction) => 
       return next();
     }
   } catch (e) {
-    logger.debug(`Error: while constructing url or validating key for ${apiKey} and ${urlStr}: ${e}`);
+    logger.warn(`Error: while constructing url or validating key for ${apiKey} and ${urlStr}: ${e}`);
   }
   res.sendStatus(401);
 };


### PR DESCRIPTION
## Feature/Problem Description
The value for `req.hostname` is not always correct depending on proxy usage. To remedy this, we can either pull the "correct" hostname from a request body's `response_url` property if present, or otherwise use the `x-forwarded-for` HTTP header.

## Solution (Changes Made)
* Create `URL` object from `reponse_url` value or header `x-forwarded-for`.
  * Pull `hostname` from this object.
* Add `info` logging for `urlStr` and `apiKey` values.

