### PR TITLE
Feature: Landing Page and Jobs in Queue when Hitting `/status`

### DIFF
--- a/orchestrator/packages/api/src/index.ts
+++ b/orchestrator/packages/api/src/index.ts
@@ -6,6 +6,7 @@ import express = require("express");
 import cors = require("cors");
 import dockerImagesRouter from "./routes/docker-images";
 import holdingPenRouter from "./routes/holding-pen";
+import { getNumJobsEnqueued } from "@codegrade-orca/db";
 
 const CONFIG = getConfig();
 
@@ -14,8 +15,9 @@ app.use(cors());
 app.use(express.json());
 
 app.use("/api/v1", gradingQueueRouter, dockerImagesRouter, holdingPenRouter);
-app.use("/status", (_req, res) => res.json({"message": "ok"}));
+app.use("/status", async (_req, res) => res.json({"message": "ok", "numJobs": await getNumJobsEnqueued()}));
 app.use("/images", express.static(CONFIG.dockerImageFolder));
+app.use("/", async(_req, res) => res.send('<h1>Orca Web API</h1>'));
 
 app.listen(CONFIG.api.port, () => {
   if (!existsSync(CONFIG.dockerImageFolder)) {

--- a/orchestrator/packages/db/src/server-operations/get-num-jobs-enqueued.ts
+++ b/orchestrator/packages/db/src/server-operations/get-num-jobs-enqueued.ts
@@ -1,0 +1,6 @@
+import prismaInstance from '../prisma-instance';
+
+const getNumJobsEnqueued = (): Promise<number> =>
+  prismaInstance.$transaction((tx) => tx.job.count());
+
+export default getNumJobsEnqueued;

--- a/orchestrator/packages/db/src/server-operations/index.ts
+++ b/orchestrator/packages/db/src/server-operations/index.ts
@@ -2,8 +2,13 @@ import enqueueImageBuild from "./enqueue-image-build";
 import getAllGradingJobs from "./get-jobs";
 import deleteJob from "./delete-job";
 import getJobStatus, { JobQueueStatus } from "./job-queue-status";
+import getNumJobsEnqueued from "./get-num-jobs-enqueued";
 
-export { enqueueImageBuild };
-export { getAllGradingJobs };
-export { deleteJob };
-export { getJobStatus, JobQueueStatus };
+export {
+  enqueueImageBuild,
+  getAllGradingJobs,
+  deleteJob,
+  getJobStatus,
+  JobQueueStatus,
+  getNumJobsEnqueued
+};


### PR DESCRIPTION
## Feature/Problem Description
Orca has no landing page for it's `/` (root) route, and gives no information about the number of jobs in the queue when hitting its `/status` endpoint.

## Solution (Changes Made)
* Basic message in `h1` tag for landing page.
* Include enqueued jobs count with `/status` response body.

