### PR TITLE
refactor: consolidate f strings for sha file and images url

### DIFF
--- a/worker/orca_grader/__main__.py
+++ b/worker/orca_grader/__main__.py
@@ -19,7 +19,7 @@ from orca_grader.executor.builder.grading_job_executor_builder import GradingJob
 from orca_grader.job_retrieval.local.local_grading_job_retriever import LocalGradingJobRetriever
 from orca_grader.job_retrieval.postgres.grading_job_retriever import PostgresGradingJobRetriever
 from orca_grader.docker_utils.images.utils import does_image_exist_locally
-from orca_grader.docker_utils.images.image_loading import retrieve_image_tgz_from_url, load_image_from_tgz
+from orca_grader.docker_utils.images.image_loading import retrieve_image_tgz_for_sha, load_image_from_tgz
 from orca_grader.job_termination.nonblocking_thread_executor import NonBlockingThreadPoolExecutor
 from orca_grader.job_termination.stop_worker import GracefulKiller
 from orca_grader.validations.exceptions import InvalidGradingJobJSONException
@@ -128,9 +128,7 @@ def run_grading_job(grading_job: GradingJobJSON, no_container: bool,
         container_sha = grading_job["grader_image_sha"]
         if not does_image_exist_locally(f"grader-{container_sha}"):
             _LOGGER.info(f"No image with tag grader-{container_sha} found in local docker registry.")
-            retrieve_image_tgz_from_url(
-                container_sha, f"{APP_CONFIG.orca_web_server_host}/images/{container_sha}.tgz"
-            )
+            retrieve_image_tgz_for_sha(container_sha)
             load_image_from_tgz("{0}.tgz".format(container_sha))
         if container_command:
             handle_grading_job(

--- a/worker/orca_grader/__main__.py
+++ b/worker/orca_grader/__main__.py
@@ -19,7 +19,7 @@ from orca_grader.executor.builder.grading_job_executor_builder import GradingJob
 from orca_grader.job_retrieval.local.local_grading_job_retriever import LocalGradingJobRetriever
 from orca_grader.job_retrieval.postgres.grading_job_retriever import PostgresGradingJobRetriever
 from orca_grader.docker_utils.images.utils import does_image_exist_locally
-from orca_grader.docker_utils.images.image_loading import retrieve_image_tgz_for_sha, load_image_from_tgz
+from orca_grader.docker_utils.images.image_loading import retrieve_image_tgz_for_unique_name, load_image_from_tgz
 from orca_grader.job_termination.nonblocking_thread_executor import NonBlockingThreadPoolExecutor
 from orca_grader.job_termination.stop_worker import GracefulKiller
 from orca_grader.validations.exceptions import InvalidGradingJobJSONException
@@ -128,8 +128,8 @@ def run_grading_job(grading_job: GradingJobJSON, no_container: bool,
         container_sha = grading_job["grader_image_sha"]
         if not does_image_exist_locally(f"grader-{container_sha}"):
             _LOGGER.info(f"No image with tag grader-{container_sha} found in local docker registry.")
-            retrieve_image_tgz_for_sha(container_sha)
-            load_image_from_tgz("{0}.tgz".format(container_sha))
+            tgz_file_name = retrieve_image_tgz_for_unique_name(container_sha)
+            load_image_from_tgz(tgz_file_name)
         if container_command:
             handle_grading_job(
                 grading_job, container_sha, container_command)

--- a/worker/orca_grader/docker_utils/images/image_loading.py
+++ b/worker/orca_grader/docker_utils/images/image_loading.py
@@ -2,13 +2,15 @@ import logging
 import os
 import subprocess
 from orca_grader.common.services.download_file import download_file
+from orca_grader.config import APP_CONFIG
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def retrieve_image_tgz_from_url(container_sha: str, images_url: str) -> None:
-    file_name = "{0}.tgz".format(container_sha)
+def retrieve_image_tgz_for_sha(container_sha: str) -> None:
+    file_name = f"{container_sha}.tgz"
+    images_url = f"{APP_CONFIG.orca_web_server_host}/images/{file_name}"
     _LOGGER.debug(f"Attempting to download image from {images_url}")
     download_file(images_url, file_name)
     _LOGGER.debug("Image downloaded.")
@@ -23,8 +25,10 @@ def load_image_from_tgz(tgz_file_path: str) -> None:
     ]
     _LOGGER.debug(f"Attempting to load image from file {tgz_file_path}")
     result = subprocess.run(program_args, check=True, capture_output=True)
-    _LOGGER.debug(f"Docker save stdout: {result.stdout.decode() if result.stdout is not None else '<None>' }")
-    _LOGGER.debug(f"Docker save stderr: {result.stderr.decode() if result.stderr is not None else '<None>' }")
+    _LOGGER.debug(
+        f"Docker save stdout: {result.stdout.decode() if result.stdout is not None else '<None>' }")
+    _LOGGER.debug(
+        f"Docker save stderr: {result.stderr.decode() if result.stderr is not None else '<None>' }")
     _LOGGER.debug("Image loaded.")
     # os.remove(tgz_file_path)  # To save resources, clean up tgz after load.
     # _LOGGER.debug("Image tgz file removed.")

--- a/worker/orca_grader/docker_utils/images/image_loading.py
+++ b/worker/orca_grader/docker_utils/images/image_loading.py
@@ -8,12 +8,13 @@ from orca_grader.config import APP_CONFIG
 _LOGGER = logging.getLogger(__name__)
 
 
-def retrieve_image_tgz_for_sha(container_sha: str) -> None:
-    file_name = f"{container_sha}.tgz"
+def retrieve_image_tgz_for_unique_name(unique_name: str) -> str:
+    file_name = f"{unique_name}.tgz"
     images_url = f"{APP_CONFIG.orca_web_server_host}/images/{file_name}"
     _LOGGER.debug(f"Attempting to download image from {images_url}")
     download_file(images_url, file_name)
     _LOGGER.debug("Image downloaded.")
+    return file_name
 
 
 def load_image_from_tgz(tgz_file_path: str) -> None:
@@ -23,12 +24,20 @@ def load_image_from_tgz(tgz_file_path: str) -> None:
         "-i",
         tgz_file_path
     ]
-    _LOGGER.debug(f"Attempting to load image from file {tgz_file_path}")
-    result = subprocess.run(program_args, check=True, capture_output=True)
-    _LOGGER.debug(
-        f"Docker save stdout: {result.stdout.decode() if result.stdout is not None else '<None>' }")
-    _LOGGER.debug(
-        f"Docker save stderr: {result.stderr.decode() if result.stderr is not None else '<None>' }")
-    _LOGGER.debug("Image loaded.")
-    # os.remove(tgz_file_path)  # To save resources, clean up tgz after load.
-    # _LOGGER.debug("Image tgz file removed.")
+    try:
+        _LOGGER.debug(f"Attempting to load image from file {tgz_file_path}")
+        result = subprocess.run(program_args, check=True, capture_output=True)
+        _LOGGER.debug(
+            f"Docker save stdout: {result.stdout.decode() if result.stdout is not None else '<None>' }")
+        _LOGGER.debug(
+            f"Docker save stderr: {result.stderr.decode() if result.stderr is not None else '<None>' }")
+        _LOGGER.debug("Image loaded.")
+        # os.remove(tgz_file_path)  # To save resources, clean up tgz after load.
+        # _LOGGER.debug("Image tgz file removed.")
+    except Exception as e:
+        if isinstance(e, subprocess.CalledProcessError):
+            _LOGGER.debug(
+                f"Docker save stdout: {e.stdout.decode() if e.stdout is not None else '<None>' }")
+            _LOGGER.debug(
+                f"Docker save stderr: {e.stderr.decode() if e.stderr is not None else '<None>' }")
+        raise e

--- a/worker/orca_grader/tests/docker_images/test_docker_image_loading.py
+++ b/worker/orca_grader/tests/docker_images/test_docker_image_loading.py
@@ -2,7 +2,7 @@ import subprocess
 import unittest
 from os import path
 
-from orca_grader.docker_utils.images.image_loading import retrieve_image_tgz_for_sha, \
+from orca_grader.docker_utils.images.image_loading import retrieve_image_tgz_for_unique_name, \
     load_image_from_tgz
 from orca_grader.docker_utils.images.utils import does_image_exist_locally
 
@@ -20,7 +20,7 @@ class TestDockerImageLoading(unittest.TestCase):
         return super().setUpClass()
 
     def test_image_download_and_loading(self):
-        retrieve_image_tgz_for_sha("hello-world")
+        retrieve_image_tgz_for_unique_name("hello-world")
         self.assertTrue(path.exists("hello-world.tgz"))
         load_image_from_tgz("hello-world.tgz")
         self.assertTrue(does_image_exist_locally("hello-world"))

--- a/worker/orca_grader/tests/docker_images/test_docker_image_loading.py
+++ b/worker/orca_grader/tests/docker_images/test_docker_image_loading.py
@@ -2,7 +2,7 @@ import subprocess
 import unittest
 from os import path
 
-from orca_grader.docker_utils.images.image_loading import retrieve_image_tgz_from_url, \
+from orca_grader.docker_utils.images.image_loading import retrieve_image_tgz_for_sha, \
     load_image_from_tgz
 from orca_grader.docker_utils.images.utils import does_image_exist_locally
 
@@ -20,8 +20,7 @@ class TestDockerImageLoading(unittest.TestCase):
         return super().setUpClass()
 
     def test_image_download_and_loading(self):
-        retrieve_image_tgz_from_url(
-            "hello-world", "http://localhost:9000/images/hello-world.tgz")
+        retrieve_image_tgz_for_sha("hello-world")
         self.assertTrue(path.exists("hello-world.tgz"))
         load_image_from_tgz("hello-world.tgz")
         self.assertTrue(does_image_exist_locally("hello-world"))


### PR DESCRIPTION
## Feature/Problem Description
Passing around a grader image's SHA Sum (for downloading and checking against local file system) was unclear and redundant when calling the `retrieve_image_tgz_from_url` function. This PR seeks to consolidate that logic.

## Solution (Changes Made)
* Function now takes in _just_ the SHA sum.
* File name generated once, and then used for creating the URL.

