### PR TITLE
Use Docker as Source of Truth for Image Names

### DIFF
--- a/worker/orca_grader/__main__.py
+++ b/worker/orca_grader/__main__.py
@@ -132,6 +132,7 @@ def run_grading_job(grading_job: GradingJobJSON, no_container: bool,
             _LOGGER.info(f"No image {image_name} found in local docker registry.")
             tgz_file_name = retrieve_image_tgz_for_unique_name(container_sha)
             image_name = load_image_from_tgz(tgz_file_name)
+            _LOGGER.debug(f"Expected image name: {image_name}")
             if image_name is None:
                 raise NoImageNameFoundException("No image was found from either the "
                                                 "local registry or `docker load`"

--- a/worker/orca_grader/docker_utils/images/image_loading.py
+++ b/worker/orca_grader/docker_utils/images/image_loading.py
@@ -36,7 +36,7 @@ def load_image_from_tgz(tgz_file_path: str) -> Optional[str]:
         _LOGGER.debug("Image loaded.")
         # os.remove(tgz_file_path)  # To save resources, clean up tgz after load.
         # _LOGGER.debug("Image tgz file removed.")
-        return result.stderr and get_name_from_load_output(result.stdout)
+        return result.stdout and get_name_from_load_output(result.stdout.decode())
     except Exception as e:
         if isinstance(e, subprocess.CalledProcessError):
             _LOGGER.debug(
@@ -45,7 +45,8 @@ def load_image_from_tgz(tgz_file_path: str) -> Optional[str]:
                 f"Docker save stderr: {e.stderr.decode() if e.stderr is not None else '<None>' }")
         raise e
 
+
 def get_name_from_load_output(docker_load_stdout: str) -> Optional[str]:
-    pattern = re.compile(r"^Loaded image: ([a-zA-Z0-9/:_-]+)")
+    pattern = re.compile(r"^Loaded image: ([a-zA-Z0-9:_-]+)")
     match = pattern.match(docker_load_stdout)
-    return match.group(1) if len(match.groups()) == 2 else None
+    return match.group(1).replace(':latest', '') if len(match.groups()) <= 2 else None

--- a/worker/orca_grader/docker_utils/images/image_loading.py
+++ b/worker/orca_grader/docker_utils/images/image_loading.py
@@ -31,10 +31,10 @@ def load_image_from_tgz(tgz_file_path: str) -> str:
     _LOGGER.debug("Image loaded.")
     # os.remove(tgz_file_path)  # To save resources, clean up tgz after load.
     # _LOGGER.debug("Image tgz file removed.")
-    return get_name_from_load_output(result.stderr.decode())
+    return result.stderr and get_name_from_load_output(result.stderr.decode())
 
 
-def get_name_from_load_output(stderr: str) -> str:
+def get_name_from_load_output(stderr: str) -> Optional[str]:
     pattern = re.compile(r"^Loaded image\: (.*)$")
     match = pattern.match(stderr)
-    return match.group(1)
+    return match.group(1) if len(match.groups()) == 2 else None

--- a/worker/orca_grader/docker_utils/images/image_loading.py
+++ b/worker/orca_grader/docker_utils/images/image_loading.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import subprocess
 from orca_grader.common.services.download_file import download_file
 from orca_grader.config import APP_CONFIG
@@ -16,7 +17,7 @@ def retrieve_image_tgz_for_sha(container_sha: str) -> None:
     _LOGGER.debug("Image downloaded.")
 
 
-def load_image_from_tgz(tgz_file_path: str) -> None:
+def load_image_from_tgz(tgz_file_path: str) -> str:
     program_args = [
         "docker",
         "load",
@@ -25,10 +26,19 @@ def load_image_from_tgz(tgz_file_path: str) -> None:
     ]
     _LOGGER.debug(f"Attempting to load image from file {tgz_file_path}")
     result = subprocess.run(program_args, check=True, capture_output=True)
-    _LOGGER.debug(
-        f"Docker save stdout: {result.stdout.decode() if result.stdout is not None else '<None>' }")
-    _LOGGER.debug(
-        f"Docker save stderr: {result.stderr.decode() if result.stderr is not None else '<None>' }")
+    _LOGGER.debug(f"Docker save stdout: {result.stdout.decode() if result.stdout is not None else '<None>' }")
+    _LOGGER.debug(f"Docker save stderr: {result.stderr.decode() if result.stderr is not None else '<None>' }")
     _LOGGER.debug("Image loaded.")
     # os.remove(tgz_file_path)  # To save resources, clean up tgz after load.
     # _LOGGER.debug("Image tgz file removed.")
+    return get_name_from_load_output(result.stderr.decode())
+
+
+def get_name_from_load_output(stderr: str) -> str:
+    pattern = re.compile(r"^Loaded image\: (.*)$")
+    match = pattern.match(stderr)
+    return match.group(1)
+
+
+if __name__ == '__main__':
+    print(get_name_from_load_output("Loaded image: orca-grader-base:latest\n"))

--- a/worker/orca_grader/docker_utils/images/image_loading.py
+++ b/worker/orca_grader/docker_utils/images/image_loading.py
@@ -38,7 +38,3 @@ def get_name_from_load_output(stderr: str) -> str:
     pattern = re.compile(r"^Loaded image\: (.*)$")
     match = pattern.match(stderr)
     return match.group(1)
-
-
-if __name__ == '__main__':
-    print(get_name_from_load_output("Loaded image: orca-grader-base:latest\n"))

--- a/worker/orca_grader/docker_utils/images/image_loading.py
+++ b/worker/orca_grader/docker_utils/images/image_loading.py
@@ -36,7 +36,7 @@ def load_image_from_tgz(tgz_file_path: str) -> Optional[str]:
         _LOGGER.debug("Image loaded.")
         # os.remove(tgz_file_path)  # To save resources, clean up tgz after load.
         # _LOGGER.debug("Image tgz file removed.")
-        return result.stderr and get_name_from_load_output(result.stderr)
+        return result.stderr and get_name_from_load_output(result.stdout)
     except Exception as e:
         if isinstance(e, subprocess.CalledProcessError):
             _LOGGER.debug(
@@ -45,7 +45,7 @@ def load_image_from_tgz(tgz_file_path: str) -> Optional[str]:
                 f"Docker save stderr: {e.stderr.decode() if e.stderr is not None else '<None>' }")
         raise e
 
-def get_name_from_load_output(stderr: str) -> Optional[str]:
-    pattern = re.compile(r"^Loaded image\: (.*)$")
-    match = pattern.match(stderr)
+def get_name_from_load_output(docker_load_stdout: str) -> Optional[str]:
+    pattern = re.compile(r"^Loaded image: ([a-zA-Z0-9/:_-]+)")
+    match = pattern.match(docker_load_stdout)
     return match.group(1) if len(match.groups()) == 2 else None

--- a/worker/orca_grader/docker_utils/images/image_name.py
+++ b/worker/orca_grader/docker_utils/images/image_name.py
@@ -1,0 +1,15 @@
+import logging
+from typing import Optional
+from orca_grader.docker_utils.images.utils import get_all_docker_images
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_image_name_for_sha(container_sha: str) -> Optional[str]:
+    matching_images = list(
+        filter(lambda name: container_sha in name, get_all_docker_images()))
+    if len(matching_images) > 1:
+        _LOGGER.warn("More than one image found with given "
+                     f"SHA sum: {', '.join(matching_images)}")
+    _LOGGER.debug(matching_images)
+    return matching_images[0] if len(matching_images) > 0 else None

--- a/worker/orca_grader/exceptions.py
+++ b/worker/orca_grader/exceptions.py
@@ -1,8 +1,18 @@
 class InvalidWorkerStateException(Exception):
-  """
-  Exception used to signal the the worker should be shut down altogether.
-  """
-  
-  def __init__(self, msg: str = "The worker has reached an unclean state; this is most likely caused " \
-               "by failure to shutdown a running job container.") -> None:
-    self.msg = msg
+    """
+    Exception used to signal the the worker should be shut down altogether.
+    """
+
+    def __init__(self, msg: str = "The worker has reached an unclean state; this is most likely caused "
+                 "by failure to shutdown a running job container.") -> None:
+        self.msg = msg
+
+
+class NoImageNameFoundException(Exception):
+    """
+    Used to signal when an image name was not found in the registry or from
+    a `docker load` command.
+    """
+
+    def __init__(self, msg: str):
+        super(msg)

--- a/worker/orca_grader/exceptions.py
+++ b/worker/orca_grader/exceptions.py
@@ -15,4 +15,4 @@ class NoImageNameFoundException(Exception):
     """
 
     def __init__(self, msg: str):
-        super(msg)
+        self.msg = msg


### PR DESCRIPTION
## Feature/Problem Description
It is possible for Docker to load in a `.tgz` from a different host machine with the Repository `<hostname>/<image-group-name>`.

To remedy this, instead of assuming the name for the container will _always_ be `grader-<sha>`, we now turn to:
1. The `docker image ls` output (where an image name contains the SHA) _or_
2. The output of the `docker load -i <tgz-file>` command, which when successful will output the name of the image saved to the local registry.


## Solution (Changes Made)
* Fetch docker image name from local registry given SHA sum.
* Use regex to get image name from `docker load` output.
* Use image name instead of container SHA for building the executor.