### PR TITLE
Utilize Docker Start/CP for JSON Handling

### DIFF
--- a/worker/orca_grader/executor/builder/docker_grading_job_executor_builder.py
+++ b/worker/orca_grader/executor/builder/docker_grading_job_executor_builder.py
@@ -1,5 +1,6 @@
 import time
 import re
+from subprocess import CompletedProcess
 from typing import Callable, Dict, List
 from orca_grader.docker_utils.containers import get_all_container_names
 from orca_grader.executor.builder.grading_job_executor_builder import GradingJobExecutorBuilder
@@ -17,8 +18,9 @@ class DockerGradingJobExecutorBuilder(GradingJobExecutorBuilder):
                  container_command: List[str] = __DEFAULT_CONTIANER_CMD) -> None:
         self.__image_name = image_name
         self.__container_command = container_command
-        self.__file_mappings: Dict[str, str] = dict()
+        self.__volume_mappings: Dict[str, str] = dict()
         self.__env_variable_mappings: Dict[str, str] = dict()
+        self.__to_copy = dict()
 
     def __num_containers_with_same_sha(self) -> int:
         filter_op: Callable[[str], bool] = lambda n: n.startswith(
@@ -26,23 +28,63 @@ class DockerGradingJobExecutorBuilder(GradingJobExecutorBuilder):
         return len(list(filter(filter_op, get_all_container_names())))
 
     def add_docker_volume_mapping(self, local_path: str, container_path: str) -> None:
-        self.__file_mappings[local_path] = container_path
+        self.__volume_mappings[local_path] = container_path
 
     def add_docker_environment_variable_mapping(self, name: str, value: str) -> None:
         self.__env_variable_mappings[name] = value
 
-    def build(self) -> GradingJobExecutor:
-        # TODO: How could we maintain a 'reference count' for a unique id?
-        sanitized_image_name = re.sub(r'[^a-zA-Z0-9_.-]', '_', self.__image_name)
-        container_name = f"{sanitized_image_name}_{int(time.time() * 100_000_000)}"
-        program_sequence = ["docker", "run", "--rm", "--name", container_name]
+    def add_paths_for_docker_cp(self, src: str, dest: str) -> None:
+        self.__to_copy[src] = dest
+
+    def __create_container_create_command(self, container_name):
+        program_sequence = [
+            "docker",
+            "container",
+            "create",
+            "--rm",
+            "--name",
+            container_name
+        ]
         program_sequence.extend(["--network", "host"])
         for name, value in self.__env_variable_mappings.items():
             program_sequence.append("-e")
             program_sequence.append(f'{name}={value}')
-        for local_path, container_path in self.__file_mappings.items():
+        for local_path, container_path in self.__volume_mappings.items():
             program_sequence.append("-v")
             program_sequence.append(f"{local_path}:{container_path}")
         program_sequence.append(self.__image_name)
         program_sequence.extend(self.__container_command)
-        return DockerGradingJobExecutor(create_runnable_job_subprocess(program_sequence), container_name)
+        return create_runnable_job_subprocess(program_sequence)
+
+    def __create_container_start_subprocess(self, container_name: str) -> Callable[[], CompletedProcess]:
+        program_args = [
+            "docker",
+            "container",
+            "start",
+            container_name
+        ]
+        return create_runnable_job_subprocess(program_args)
+
+
+    def __create_container_cp_subprocesses(self, container_name: str) -> List[Callable[[], CompletedProcess]]:
+        subprocs = []
+        for src, dest in self.__to_copy.items():
+            program_sequence = [
+                "docker",
+                "container",
+                "cp",
+                src,
+                f"{container_name}:{dest}"
+            ]
+            subprocs.append(create_runnable_job_subprocess(program_sequence))
+        return subprocs
+
+    def build(self) -> GradingJobExecutor:
+        # TODO: How could we maintain a 'reference count' for a unique id?
+        sanitized_image_name = re.sub(
+            r'[^a-zA-Z0-9_.-]', '_', self.__image_name)
+        container_name = f"{sanitized_image_name}_{int(time.time() * 100_000_000)}"
+        subprocs = [self.__create_container_create_command(container_name)]
+        subprocs.extend(self.__create_container_cp_subprocesses(container_name))
+        subprocs.append(self.__create_container_start_subprocess(container_name))
+        return DockerGradingJobExecutor(subprocs, container_name)

--- a/worker/orca_grader/executor/docker_grading_job_executor.py
+++ b/worker/orca_grader/executor/docker_grading_job_executor.py
@@ -1,7 +1,7 @@
 import subprocess
 from orca_grader.exceptions import InvalidWorkerStateException
 from orca_grader.executor.grading_job_executor import GradingJobExecutor
-from typing import Callable
+from typing import Callable, List
 from subprocess import CompletedProcess, TimeoutExpired
 
 
@@ -11,8 +11,8 @@ class DockerGradingJobExecutor(GradingJobExecutor):
     # seconds; SIGKILL (if necessary) is sent at end of timeout above.
     __STOP_BUFFER = 5
 
-    def __init__(self, grading_subprocess: Callable[[], CompletedProcess], container_name: str) -> None:
-        super().__init__(grading_subprocess)
+    def __init__(self, grading_subprocesses: List[Callable[[], CompletedProcess]], container_name: str) -> None:
+        super().__init__(grading_subprocesses)
         self.__container_name = container_name
 
     def _handle_timeout(self, time_err: TimeoutExpired):

--- a/worker/orca_grader/executor/grading_job_executor.py
+++ b/worker/orca_grader/executor/grading_job_executor.py
@@ -1,18 +1,63 @@
-from subprocess import CompletedProcess, TimeoutExpired
-from typing import Callable
+import logging
+from subprocess import CompletedProcess, CalledProcessError, TimeoutExpired
+from typing import Callable, List
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ExecutorResult():
+
+    def __init__(self, results: List[str], was_successful: bool,
+                 did_timeout: bool):
+        self.results = results
+        self.was_successful = was_successful
+        self.did_timeout = did_timeout
+
 
 class GradingJobExecutor():
 
-  def __init__(self, grading_subprocess: Callable[[], CompletedProcess]) -> None:
-    self._grading_subprocess = grading_subprocess
+    def __init__(self, grading_subprocesses: List[Callable[[], CompletedProcess]]) -> None:
+        self._grading_subprocesses = grading_subprocesses
 
-  def execute(self) -> CompletedProcess:
-    try:
-      result = self._grading_subprocess()
-      return result
-    except TimeoutExpired as time_err:
-      self._handle_timeout(time_err)
+    def execute(self) -> ExecutorResult:
+        results = []
+        successful = True
+        timed_out = False
+        try:
+            for sub_proc in self._grading_subprocesses:
+                completed = sub_proc()
+                cmd = completed.args if type(
+                    completed.args) is str else " ".join(completed.args)
+                results.append(format_completed_proc_output(
+                               cmd,
+                               '' if completed.stdout is None else
+                               completed.stdout.decode(),
+                               '' if completed.stderr is None else
+                               completed.stderr.decode()))
+        except CalledProcessError as ce:
+            results.append(format_completed_proc_output(
+                ce.cmd,
+                '' if ce.stdout is None else ce.stdout.decode(),
+                '' if ce.stderr is None else ce.stderr.decode()
+            ))
+            successful = False
+        except TimeoutExpired as te:
+            self._handle_timeout(te)
+            timeout_str = f"Timeout limit reached while execution grading job.\n{format_completed_proc_output(te.cmd)}"
+            _LOGGER.warn(timeout_str)
+            results.append(timeout_str)
+            successful = False
+            timed_out = True
+        except Exception as e:
+            _LOGGER.error(f"Encountered exception while execution job: {e}")
+            results.append(str(e))
+            successful = False
+        return ExecutorResult(results, successful, timed_out)
 
-  def _handle_timeout(self, time_err: TimeoutExpired):
-    raise time_err
+    def _handle_timeout(self, time_err: TimeoutExpired):
+        _LOGGER.warn("Timeout handler unimplemented for GradingJobExecutor. Ensure concrete class implements this.")
 
+
+def format_completed_proc_output(cmd: str, stdout: str = '', stderr: str = '') -> str:
+    return f"Cmd: {cmd}\nStdout: {stdout}\nStderr: {stderr}"


### PR DESCRIPTION
## Feature/Problem Description
It's not clear that `docker volume` mappings are good enough for the tempfile used with the grading job json. We now look to rework running containers with a combination of `docker container create`, `docker container cp`, and `docker container start`.

## Solution (Changes Made)
* Builder now has option for adding files _to copy_
* Builder creates subprocesses for:
  * Docker's container create command
  * Docker's container cp command
  * Docker's container start command
* `__main__` now handles new result type from executor.


