### PR TITLE
Reinstate Log Levels and Original Functionality

### DIFF
--- a/orchestrator/packages/api/src/routes/grading-queue.ts
+++ b/orchestrator/packages/api/src/routes/grading-queue.ts
@@ -12,7 +12,7 @@ import verifyAPIKey from "../middleware/verify-api-key";
 const gradingQueueRouter = Router();
 
 // TODO: Add middleware/move existing validation to middleware
-gradingQueueRouter.get("/grading_queue", getGradingJobs);
+// gradingQueueRouter.get("/grading_queue", getGradingJobs);
 gradingQueueRouter.put("/grading_queue", verifyAPIKey, createOrUpdateJob);
 gradingQueueRouter.put("/grading_queue/immediate", verifyAPIKey, createOrUpdateImmediateJob);
 gradingQueueRouter.put("/grading_queue/move", verifyAPIKey, moveJob);

--- a/worker/orca_grader/container/do_grading.py
+++ b/worker/orca_grader/container/do_grading.py
@@ -2,7 +2,6 @@ import json
 import os
 import sys
 import shutil
-import traceback
 import logging
 from pathlib import Path
 from typing import Dict, List, TextIO
@@ -88,7 +87,8 @@ if __name__ == "__main__":
     log_file_path = os.getenv("CONTAINER_LOG_FILE_PATH")
     handler = logging.FileHandler(filename=log_file_path) if \
         log_file_path is not None else logging.StreamHandler(stream=sys.stdout)
-    logging.basicConfig(level=logging.DEBUG,
+    logging.basicConfig(level=logging.INFO if APP_CONFIG.environment ==
+                        'production' else logging.DEBUG,
                         format='%(asctime)s - %(levelname)s - %(message)s',
                         handlers=[handler])
 

--- a/worker/orca_grader/docker_utils/images/image_loading.py
+++ b/worker/orca_grader/docker_utils/images/image_loading.py
@@ -10,9 +10,9 @@ from orca_grader.config import APP_CONFIG
 _LOGGER = logging.getLogger(__name__)
 
 
-def retrieve_image_tgz_for_unique_name(unique_name: str) -> str:
+def retrieve_image_tgz_for_unique_name(images_endpoint: str, unique_name: str) -> str:
     file_name = f"{unique_name}.tgz"
-    images_url = f"{APP_CONFIG.orca_web_server_host}/images/{file_name}"
+    images_url = f"{images_endpoint}/{file_name}"
     _LOGGER.debug(f"Attempting to download image from {images_url}")
     download_file(images_url, file_name)
     _LOGGER.debug("Image downloaded.")
@@ -39,8 +39,8 @@ def load_image_from_tgz(tgz_file_path: str) -> Optional[str]:
             f"Docker image ls stdout: {image_ls.stdout.decode() if image_ls.stdout is not None else '<None>'}")
         _LOGGER.debug(
             f"Docker image ls stderr: {image_ls.stderr.decode() if image_ls.stderr is not None else '<None>'}")
-        # os.remove(tgz_file_path)  # To save resources, clean up tgz after load.
-        # _LOGGER.debug("Image tgz file removed.")
+        os.remove(tgz_file_path)  # To save resources, clean up tgz after load.
+        _LOGGER.debug("Image tgz file removed.")
         return result.stdout and get_name_from_load_output(result.stdout.decode())
     except Exception as e:
         if isinstance(e, subprocess.CalledProcessError):

--- a/worker/orca_grader/tests/docker_images/test_docker_image_loading.py
+++ b/worker/orca_grader/tests/docker_images/test_docker_image_loading.py
@@ -7,7 +7,7 @@ from orca_grader.docker_utils.images.image_loading import retrieve_image_tgz_for
 from orca_grader.docker_utils.images.utils import does_image_exist_locally
 
 
-def _remove_example_contianer() -> None:
+def _remove_example_container() -> None:
     subprocess.run(["docker", "image", "rm", "hello-world"],
                    stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
@@ -16,12 +16,15 @@ class TestDockerImageLoading(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        _remove_example_contianer()
+        _remove_example_container()
         return super().setUpClass()
 
     def test_image_download_and_loading(self):
-        retrieve_image_tgz_for_unique_name("hello-world")
+        retrieve_image_tgz_for_unique_name("http://localhost:9000/images", "hello-world")
         self.assertTrue(path.exists("hello-world.tgz"))
         load_image_from_tgz("hello-world.tgz")
         self.assertTrue(does_image_exist_locally("hello-world"))
         self.assertFalse(path.exists("hello-world.tgz"))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Feature/Problem Description
With deployment chaos _mostly_ over, we now need to reinstate logging level rules, as well as the handling of tempfiles and .tgz image files. We also need to remove exposition of the API endpoint that leaks vulnerable job info. 

## Solution (Changes Made)
* Log level back to being dependent on environment.
* Tempfiles removed on exit of the `with` context.
* TGZ files removed after loading.
  * Function for retrieval of tgz file takes in an images _endpoint_, allowing CI to run tests properly again.

## Additional Notes
* Caught bug where the updated DB ID for a job that has been re-enqueued was not correctly passed to the function that notifies the client of a job's new location; this has been fixed by ensuring it is passed in.

