### PR TITLE
Validation APIs: GradingJobConfig and GradingScript

### DIFF
--- a/orchestrator/packages/api/src/controllers/docker-image-controller.ts
+++ b/orchestrator/packages/api/src/controllers/docker-image-controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { errorResponse, formatValidationErrors } from "./utils";
 import {
-    graderImageExists,
+  graderImageExists,
   logger,
   validations,
 } from "@codegrade-orca/common";
@@ -10,7 +10,12 @@ import { GradingQueueOperationException, enqueueImageBuild, imageIsAwaitingBuild
 export const createGraderImage = async (req: Request, res: Response) => {
   const validator = validations.graderImageBuildRequest;
   if (!validator(req.body)) {
-    return errorResponse(res, 400, formatValidationErrors("The request body to build a grader image is invalid.", validator.errors));
+    return errorResponse(res, 400,
+      [
+        "The request body to build a grader image is invalid.",
+        ...formatValidationErrors(validator.errors)
+      ]
+    );
   }
   const { dockerfile_sha_sum } = req.body;
   if (graderImageExists(dockerfile_sha_sum)) {

--- a/orchestrator/packages/api/src/controllers/grading-queue-controller.ts
+++ b/orchestrator/packages/api/src/controllers/grading-queue-controller.ts
@@ -110,7 +110,12 @@ export const createOrUpdateImmediateJob = async (
 ) => {
   const validator = validations.gradingJobConfig
   if (!validator(req.body)) {
-    return errorResponse(res, 400, formatValidationErrors("The given grading job was invalid.", validator.errors));
+    return errorResponse(res, 400,
+      [
+        "The given grading job was invalid.",
+        ...formatValidationErrors(validator.errors)
+      ]
+    );
   }
   try {
     const status = await putJobInQueue(req.body, true);
@@ -130,7 +135,12 @@ export const createOrUpdateImmediateJob = async (
 export const createOrUpdateJob = async (req: Request, res: Response) => {
   const validator = validations.gradingJobConfig
   if (!validator(req.body)) {
-    return errorResponse(res, 400, formatValidationErrors("The given grading job was invalid.", validator.errors));
+    return errorResponse(res, 400,
+      [
+        "The given immediate grading job was invalid.",
+        ...formatValidationErrors(validator.errors)
+      ]
+    );
   }
   try {
     const status = await putJobInQueue(req.body, false);
@@ -197,4 +207,3 @@ export const jobStatus = async (req: Request, res: Response) => {
     return res.json(`Your job is number ${queuePosition} in the queue.`);
   }
 }
-

--- a/orchestrator/packages/api/src/controllers/utils.ts
+++ b/orchestrator/packages/api/src/controllers/utils.ts
@@ -1,5 +1,5 @@
 import { GradingJobConfig, GradingJobResult, logger, validations } from "@codegrade-orca/common";
-import { ValidationErrors } from "@codegrade-orca/common/src/validations";
+import { ValidationErrors } from "@codegrade-orca/common";
 import { Response } from "express";
 
 export const errorResponse = (
@@ -15,13 +15,10 @@ export const errorResponse = (
   return res.status(status).json({ errors: errors });
 };
 
-export const formatValidationErrors = (description: string, validationErrors: ValidationErrors): Array<string> =>
-  [
-    description,
-    ...(validationErrors ?
-      validationErrors.map((e) => formatValidationError(e.instancePath, e.message)).filter((s) => s !== '') :
-      [])
-  ];
+export const formatValidationErrors = (validationErrors: ValidationErrors): Array<string> =>
+  validationErrors ?
+    validationErrors.map((e) => formatValidationError(e.instancePath, e.message)).filter((s) => s !== '') :
+    [];
 
 const formatValidationError = (instancePath: string, message: string | undefined): string => {
   return `${instancePath} ${message ?? ''}`.trim();

--- a/orchestrator/packages/api/src/controllers/validations-controller.ts
+++ b/orchestrator/packages/api/src/controllers/validations-controller.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from "express";
+import { errorResponse, formatValidationErrors } from "./utils";
+import { validations } from "@codegrade-orca/common";
+
+export const gradingJobValidation = async (req: Request, res: Response) => {
+  if (!req.body || Object.keys(req.body).length === 0) {
+    return errorResponse(res, 400, ['No request body provided for grading job configuration schema validation.']);
+  }
+  const validator = validations.gradingJobConfig;
+  return validator(req.body) ?
+    res.json({ "message": "Provided request body is a valid grading job configuration." }) :
+    res.json({ "errors": formatValidationErrors(validator.errors) });
+}

--- a/orchestrator/packages/api/src/controllers/validations-controller.ts
+++ b/orchestrator/packages/api/src/controllers/validations-controller.ts
@@ -11,3 +11,13 @@ export const gradingJobValidation = async (req: Request, res: Response) => {
     res.json({ "message": "Provided request body is a valid grading job configuration." }) :
     res.json({ "errors": formatValidationErrors(validator.errors) });
 }
+
+export const gradingScriptValidation = async (req: Request, res: Response) => {
+  if (!req.body || req.body.length === 0) {
+    return errorResponse(res, 400, ['No request body provided for grading script schema validation.']);
+  }
+  const validator = validations.gradingScript;
+  return validator(req.body) ?
+    res.json({ "message": "Provided request body is a valid grading script configuration." }) :
+    res.json({ "errors": formatValidationErrors(validator.errors) });
+}

--- a/orchestrator/packages/api/src/index.ts
+++ b/orchestrator/packages/api/src/index.ts
@@ -7,6 +7,7 @@ import cors = require("cors");
 import dockerImagesRouter from "./routes/docker-images";
 import holdingPenRouter from "./routes/holding-pen";
 import { getNumJobsEnqueued } from "@codegrade-orca/db";
+import validationsRouter from "./routes/validations";
 
 const CONFIG = getConfig();
 
@@ -14,7 +15,7 @@ const app: Express = express();
 app.use(cors());
 app.use(express.json());
 
-app.use("/api/v1", gradingQueueRouter, dockerImagesRouter, holdingPenRouter);
+app.use("/api/v1", gradingQueueRouter, dockerImagesRouter, holdingPenRouter, validationsRouter);
 app.use("/status", async (_req, res) => res.json({"message": "ok", "numJobs": await getNumJobsEnqueued()}));
 app.use("/images", express.static(CONFIG.dockerImageFolder));
 app.use("/", async(_req, res) => res.send('<h1>Orca Web API</h1>'));

--- a/orchestrator/packages/api/src/index.ts
+++ b/orchestrator/packages/api/src/index.ts
@@ -16,9 +16,9 @@ app.use(cors());
 app.use(express.json());
 
 app.use("/api/v1", gradingQueueRouter, dockerImagesRouter, holdingPenRouter, validationsRouter);
-app.use("/status", async (_req, res) => res.json({"message": "ok", "numJobs": await getNumJobsEnqueued()}));
+app.get("/status", async (_req, res) => res.json({"message": "ok", "numJobs": await getNumJobsEnqueued()}));
 app.use("/images", express.static(CONFIG.dockerImageFolder));
-app.use("/", async(_req, res) => res.send('<h1>Orca Web API</h1>'));
+app.get("/", async(_req, res) => res.send('<h1>Orca Web API</h1>'));
 
 app.listen(CONFIG.api.port, () => {
   if (!existsSync(CONFIG.dockerImageFolder)) {

--- a/orchestrator/packages/api/src/routes/validations.ts
+++ b/orchestrator/packages/api/src/routes/validations.ts
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import verifyAPIKey from "../middleware/verify-api-key";
-import { gradingJobValidation } from "../controllers/validations-controller";
+import { gradingJobValidation, gradingScriptValidation } from "../controllers/validations-controller";
 
 const validationsRouter = Router();
 
 validationsRouter.post('/validate_grading_job', verifyAPIKey, gradingJobValidation);
+validationsRouter.post('/validate_grading_script', verifyAPIKey, gradingScriptValidation);
 
 export default validationsRouter;

--- a/orchestrator/packages/api/src/routes/validations.ts
+++ b/orchestrator/packages/api/src/routes/validations.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import verifyAPIKey from "../middleware/verify-api-key";
+import { gradingJobValidation } from "../controllers/validations-controller";
+
+const validationsRouter = Router();
+
+validationsRouter.post('/validate_grading_job', verifyAPIKey, gradingJobValidation);
+
+export default validationsRouter;

--- a/orchestrator/packages/common/src/index.ts
+++ b/orchestrator/packages/common/src/index.ts
@@ -1,14 +1,14 @@
 import path from "path";
 import { getConfig } from "./config";
 import logger from "./logger";
-import validations from "./validations";
+import validations, { ValidationErrors } from "./validations";
 import { existsSync } from "fs";
 
 export * from "./grading-jobs";
 export * from "./types";
 export * from "./config";
 export * from "./utils";
-export { validations };
+export { validations, ValidationErrors };
 export { logger };
 
 export const toMilliseconds = (seconds: number) => seconds * 1_000;

--- a/orchestrator/packages/common/src/types/grading-queue.ts
+++ b/orchestrator/packages/common/src/types/grading-queue.ts
@@ -36,6 +36,8 @@ export interface FileInfo {
 
 export type CollationType = "team" | "user";
 
+export type GradingScript = GradingScriptCommand[];
+
 export interface Collation {
   type: CollationType;
   id: string;
@@ -47,7 +49,7 @@ export interface GradingJobConfig {
   metadata_table: Record<string, string | string[]>;
   files: Record<string, FileInfo>;
   priority: number;
-  script: GradingScriptCommand[];
+  script: GradingScript;
   response_url: string;
   container_response_url?: string;
   grader_image_sha: string;

--- a/orchestrator/packages/common/src/validations/index.ts
+++ b/orchestrator/packages/common/src/validations/index.ts
@@ -3,17 +3,19 @@ import { collationSchema } from "./schemas/shared";
 import {
   gradingJobConfigSchema,
   gradingJobConfigSubSchemas,
+  gradingScriptSchema
 } from "./schemas/grading-job-config";
 import { moveJobRequestSchema } from "./schemas/move-job-request";
 import {
   GradingJobConfig,
+  GradingScript,
   MoveJobRequest,
 } from "../types/grading-queue";
 import { GraderImageBuildRequest } from "../types/image-build-service";
 import { graderImageBuildRequestSchema } from "./schemas/grader-image-build-request";
 
 let ajv = new Ajv().addSchema(collationSchema);
-ajv = gradingJobConfigSubSchemas.reduce(
+ajv = [gradingJobConfigSubSchemas].reduce(
   (prev, curr) => prev.addSchema(curr),
   ajv,
 );
@@ -22,8 +24,9 @@ export type ValidationErrors = typeof ajv.errors;
 
 export default {
   gradingJobConfig: ajv.compile<GradingJobConfig>(gradingJobConfigSchema),
+  gradingScript: ajv.compile<GradingScript>(gradingScriptSchema),
   moveJobRequest: ajv.compile<MoveJobRequest>(moveJobRequestSchema),
   graderImageBuildRequest: ajv.compile<GraderImageBuildRequest>(
     graderImageBuildRequestSchema,
-  ),
+  )
 };

--- a/orchestrator/packages/common/src/validations/schemas/grading-job-config.ts
+++ b/orchestrator/packages/common/src/validations/schemas/grading-job-config.ts
@@ -14,7 +14,7 @@ const fileInfo = {
   additionalProperties: false,
 } as const;
 
-const bashGradingScriptCommand = {
+const bashGradingScriptCommandSchema = {
   $id: "https://orca-schemas.com/grading-job-config/bash-grading-script-command",
   type: "object",
   properties: {
@@ -53,7 +53,7 @@ const bashGradingScriptCommand = {
   additionalProperties: false,
 } as const;
 
-const gradingScriptCondition = {
+const gradingScriptConditionSchema = {
   $id: "https://orca-schemas.com/grading-job-config/grading-script-condition",
   type: "object",
   properties: {
@@ -67,7 +67,7 @@ const gradingScriptCondition = {
   additionalProperties: false,
 } as const;
 
-const conditionalGradingScriptCommand = {
+const conditionalGradingScriptCommandSchema = {
   $id: "https://orca-schemas.com/grading-job-config/conditional-grading-script-command",
   type: "object",
   properties: {
@@ -102,7 +102,7 @@ const conditionalGradingScriptCommand = {
   additionalProperties: false,
 } as const;
 
-const gradingScriptCommand = {
+export const gradingScriptCommandSchema = {
   $id: "https://orca-schemas.com/grading-job-config/grading-script-command",
   oneOf: [
     {
@@ -114,12 +114,25 @@ const gradingScriptCommand = {
   ],
 } as const;
 
+export const gradingScriptSubSchemas = [
+  bashGradingScriptCommandSchema,
+  gradingScriptConditionSchema,
+  conditionalGradingScriptCommandSchema,
+  gradingScriptCommandSchema
+];
+
+export const gradingScriptSchema = {
+  $id: "https://orca-schemas.com/grading-job-config/grading-script",
+  type: "array",
+  items: {
+    $ref: "https://orca-schemas.com/grading-job-config/grading-script-command",
+  },
+} as const;
+
 export const gradingJobConfigSubSchemas = [
   fileInfo,
-  gradingScriptCommand,
-  bashGradingScriptCommand,
-  gradingScriptCondition,
-  conditionalGradingScriptCommand,
+  ...gradingScriptSubSchemas,
+  gradingScriptSchema
 ];
 
 export const gradingJobConfigSchema = {
@@ -140,12 +153,7 @@ export const gradingJobConfigSchema = {
       },
     },
     priority: { type: "number" },
-    script: {
-      type: "array",
-      items: {
-        $ref: "https://orca-schemas.com/grading-job-config/grading-script-command",
-      },
-    },
+    script: { $ref: "https://orca-schemas.com/grading-job-config/grading-script" },
     response_url: { type: "string" },
     container_response_url: { type: "string" },
     grader_image_sha: { type: "string" },


### PR DESCRIPTION
## Feature/Problem Description
Clients who use Orca should be able to check if a grading job configuration they've generated is valid; this can be accomplished by way of exposing a validation endpoint. This is the same case for the `GradingScript` component of the job, where custom graders may need to validate that in isolation.

## Solution (Changes Made)
* `/api/v1/validate_grading_job` endpoint added to check request body against `GradingJobConfig` validator.
* `/api/v1/validate_grading_script` endpoint added to check request body against the _new_ `GradingScript` validator.

## Additional Notes
* An issue was caught where, because the `/` route mapper was using Express' `use` function, it would take any route of the form `/.*` and any method (e.g., POST, GET, etc) and return the Orca API landing page if a route was given that did not exist. This is fixed by mapping it to `get` specifically.


