### PR TITLE
Script for Rebuilding Grader Base and Removing Linked Images

### DIFF
--- a/orchestrator/scripts/rebuild-grader-base
+++ b/orchestrator/scripts/rebuild-grader-base
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+cd ../../worker
+docker build -t orca-grader-base -f images/orca-grader-base.Dockerfile .
+cd ../orchestrator
+rm -rf images/*
+


### PR DESCRIPTION
## Feature/Problem Description
When changes have been made to the Worker logic, we need to rebuild the image for it, and then remove an images currently on the Orchestrator to force clients to rebuild their grader images given the new base image.

## Solution (Changes Made)
* Script added that does the following:
  * Rebuilds the worker image.
  * Removes all `.tgz` files present in `orchestrator/images`.

## Additional Notes:
To run the script, execute the following in the shell (from the project level):
```
$ cd orchestrator/scripts
$ ./rebuild-grader-base
```


