### PR TITLE
Fix/touch images on enqueue

### DIFF
--- a/orchestrator/packages/api/src/controllers/grading-queue-controller.ts
+++ b/orchestrator/packages/api/src/controllers/grading-queue-controller.ts
@@ -23,6 +23,8 @@ import {
   getJobStatus
 } from "@codegrade-orca/db";
 import { describeReleaseTiming, reservationWaitingOnRelease } from "../utils/helpers";
+import { touchGraderImageFile } from "../utils/grader-images";
+import path from "path";
 
 export const getGradingJobs = async (req: Request, res: Response) => {
   if (
@@ -120,6 +122,7 @@ export const createOrUpdateImmediateJob = async (
   try {
     const status = await putJobInQueue(req.body, true);
     logger.info(`New job from ${new URL(req.body.response_url).host} sent to ${status.location} with database id ${status.id}.`);
+    await touchGraderImageFile(req.body);
     return res.status(200).json({ message: "OK", status });
   } catch (error) {
     if (error instanceof GradingQueueOperationException) {
@@ -133,7 +136,6 @@ export const createOrUpdateImmediateJob = async (
 };
 
 export const createOrUpdateJob = async (req: Request, res: Response) => {
-  logger.debug(`createOrUpdateJob: ${JSON.stringify(req.body)}`);
   const validator = validations.gradingJobConfig
   if (!validator(req.body)) {
     logger.debug(`validator rejected job: ${JSON.stringify(validator.errors)}`);
@@ -147,6 +149,7 @@ export const createOrUpdateJob = async (req: Request, res: Response) => {
   try {
     const status = await putJobInQueue(req.body, false);
     logger.info(`New job from ${new URL(req.body.response_url).host} sent to ${status.location} with database id ${status.id}.`);
+    await touchGraderImageFile(req.body);
     return res.status(200).json({ message: "OK", status });
   } catch (err) {
     if (err instanceof GradingQueueOperationException) {

--- a/orchestrator/packages/api/src/utils/__tests__/grader-images.test.ts
+++ b/orchestrator/packages/api/src/utils/__tests__/grader-images.test.ts
@@ -1,0 +1,34 @@
+import { closeSync, openSync, rmSync, statSync } from "fs";
+import { TouchGraderImageFileError, touchGraderImageFile } from "../grader-images";
+import { getConfig, mockGradingJobConfig } from "@codegrade-orca/common";
+import path from "path";
+
+
+describe("Grader image api utils", () => {
+  const CONFIG = getConfig();
+  const testSHASum = 'grader-image-sha-sum';
+  const tgzTestPath = path.join(CONFIG.dockerImageFolder, `${testSHASum}.tgz`);
+
+  beforeAll(() => {
+    const tgzTestFP = openSync(tgzTestPath, 'w');
+    closeSync(tgzTestFP);
+  });
+
+  afterAll(() => {
+    rmSync(tgzTestPath);
+  });
+
+  it('throws and error when the grader image file doesn\'t exist', async () => {
+    const testJobConfig = { ...mockGradingJobConfig, grader_image_sha: "non-existent-sha-sum"};
+    expect(() => touchGraderImageFile(testJobConfig)).rejects.toThrow(TouchGraderImageFileError);
+  });
+
+  it('touches the file successfully when it does exist', async () => {
+    const testJobConfig = { ...mockGradingJobConfig, grader_image_sha: testSHASum };
+    const { mtimeMs: mtimeBefore } = statSync(tgzTestPath);
+    await touchGraderImageFile(testJobConfig);
+    const { mtimeMs: mtimeAfter } = statSync(tgzTestPath);
+    expect(mtimeAfter).toBeGreaterThan(mtimeBefore);
+  });
+});
+

--- a/orchestrator/packages/api/src/utils/grader-images.ts
+++ b/orchestrator/packages/api/src/utils/grader-images.ts
@@ -14,22 +14,22 @@ export const touchGraderImageFile = ({
   return new Promise((resolve, reject) => {
     const tgzFileName = `${grader_image_sha}.tgz`;
     const tgzPath = path.join(CONFIG.dockerImageFolder, tgzFileName);
+    execFile(
+      "touch",
+      ["-c", tgzPath],
+      (err, _stdout, _stderr) => {
+        if (err) {
+          return reject(err);
+        } else {
+          logger.info(`Touching grader image ${grader_image_sha}.tgz`);
+        }
+      },
+    );
     if (!existsSync(tgzPath)) {
       // We do not want to _create_ the path if it does not exist already,
       // throwing off other logic that relies on its existence.
       return reject(new TouchGraderImageFileError(`No grader image exists with name ${tgzFileName}.`));
     }
-    execFile(
-      "touch",
-      [tgzPath],
-      (err, _stdout, _stderr) => {
-        if (err) {
-          reject(err);
-        } else {
-          logger.info(`Touching grader image ${grader_image_sha}.tgz`);
-          resolve();
-        }
-      },
-    );
+    resolve();
   });
 };

--- a/orchestrator/packages/api/src/utils/grader-images.ts
+++ b/orchestrator/packages/api/src/utils/grader-images.ts
@@ -1,4 +1,4 @@
-import { getConfig, GradingJobConfig } from "@codegrade-orca/common";
+import { getConfig, GradingJobConfig, logger } from "@codegrade-orca/common";
 import { execFile } from "child_process";
 import path = require("path");
 
@@ -15,6 +15,7 @@ export const touchGraderImageFile = ({
         if (err) {
           reject(err);
         } else {
+          logger.info(`Touching grader image ${grader_image_sha}.tgz`);
           resolve();
         }
       },

--- a/orchestrator/packages/api/src/utils/grader-images.ts
+++ b/orchestrator/packages/api/src/utils/grader-images.ts
@@ -1,16 +1,27 @@
 import { getConfig, GradingJobConfig, logger } from "@codegrade-orca/common";
 import { execFile } from "child_process";
+import { existsSync } from "fs";
 import path = require("path");
 
 const CONFIG = getConfig();
+
+export class TouchGraderImageFileError extends Error {
+}
 
 export const touchGraderImageFile = ({
   grader_image_sha,
 }: GradingJobConfig): Promise<void> => {
   return new Promise((resolve, reject) => {
+    const tgzFileName = `${grader_image_sha}.tgz`;
+    const tgzPath = path.join(CONFIG.dockerImageFolder, tgzFileName);
+    if (!existsSync(tgzPath)) {
+      // We do not want to _create_ the path if it does not exist already,
+      // throwing off other logic that relies on its existence.
+      return reject(new TouchGraderImageFileError(`No grader image exists with name ${tgzFileName}.`));
+    }
     execFile(
       "touch",
-      [path.join(CONFIG.dockerImageFolder, `${grader_image_sha}.tgz`)],
+      [tgzPath],
       (err, _stdout, _stderr) => {
         if (err) {
           reject(err);

--- a/orchestrator/packages/image-build-service/src/process-request/index.ts
+++ b/orchestrator/packages/image-build-service/src/process-request/index.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import {
   getConfig,
+  logger,
 } from "@codegrade-orca/common";
 import { readdir, rm, stat } from "fs/promises";
 
@@ -23,6 +24,7 @@ export const removeStaleImageFiles = async (): Promise<Array<string>> => {
         UPPER_LIMIT_OF_TIME_SINCE_IMAGE_USE
       ) {
         await rm(pathToImage);
+        logger.info(`Removing image ${image} off Orchestrator`);
         imagesRemoved.push(image);
       }
     }),


### PR DESCRIPTION
## Feature/Problem Description
Grader images are getting removed without warning every two weeks...because we're never updating the file on the web server (orchestrator) whenever it's been used by a job. This PR rectifies this issue, `touch`ing the grader image `.tgz` file every time we:
* Enqueue a job.
* Check the status of a job.

## Solution (Changes Made)
* Controller `touches` the grader image file on job enqueue and status endpoints.

